### PR TITLE
Fix 'Key `".nix.store..."` was not found' error

### DIFF
--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -18,6 +18,7 @@ The result is a JSON object with the following fields:
 import argparse
 import json
 import os
+from os.path import isabs
 from pathlib import Path
 import subprocess
 import tempfile
@@ -230,6 +231,9 @@ def parse_module_deps(module_deps, package_prefixes, toolchain_packages):
         if (tooldep := lookup_toolchain_dep(module_dep, toolchain_packages)) is not None:
             toolchain_deps.add(tooldep)
             continue
+
+        if os.path.isabs(module_dep):
+            raise RuntimeError(f"Unexpected module dependency `{module_dep}`. Perhaps a missing `haskell_toolchain_library`?")
 
         if (pkgdep := lookup_package_dep(module_dep, package_prefixes)) is not None:
             pkgname, modname = pkgdep

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -18,7 +18,6 @@ The result is a JSON object with the following fields:
 import argparse
 import json
 import os
-from os.path import isabs
 from pathlib import Path
 import subprocess
 import tempfile

--- a/haskell/tools/generate_toolchain_library_catalog.py
+++ b/haskell/tools/generate_toolchain_library_catalog.py
@@ -71,6 +71,9 @@ def _parse_ghc_pkg_dump(lines):
         elif current_key == "import-dirs" and line.strip():
             current_package.setdefault("import-dirs", []).append(line.strip())
 
+    if current_package:
+        yield current_package
+
 
 def _construct_import_path_trie(packages):
     result = {}


### PR DESCRIPTION
Closes https://github.com/MercuryTechnologies/the-culture-repo/issues/147

This addresses errors of the form
```
    Traceback (most recent call last):
      File <builtin>, in <module>
      * prelude/haskell/compile.bzl:688, in do_compile
          for module_name in post_order_traversal(graph):
    error: Key `".nix.store.h9vyn35122fb9570y6gh34qndlwmv51d-async-2.2.4.lib.ghc-9.8.2.lib.x86_64-linux-ghc-9.8.2.async-2.2.4-InWOgiTOEySF1536J1W8dc.Control.Concurrent.Async"` was not found
      --> prelude/utils/graph_utils.bzl:60:13
       |
    60 |             rdeps[dep].append(node)
       |             ^^^^^^^^^^
```

The problem was that the output format of `ghc-pkg` changed slightly, omitting a terminal `---`, which confused the `ghc-pkg dump` parser.
This PR fixes the parser, and also introduces an additional check to produce a more informative error message in cases where a toolchain library is missing from the catalog.
