### PR TITLE
Fix issues with internal package dependencies

### DIFF
--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -80,9 +80,10 @@ def json_default_handler(o):
 
 
 def obtain_target_metadata(args):
-    ghc_depends, ghc_options = run_ghc_depends(args.ghc, args.ghc_arg, args.source)
-    th_modules = determine_th_modules(ghc_options, args.source_prefix)
     toolchain_packages = load_toolchain_packages(args.toolchain_libs)
+    ghc_args = fix_ghc_args(args.ghc_arg, toolchain_packages)
+    ghc_depends, ghc_options = run_ghc_depends(args.ghc, ghc_args, args.source)
+    th_modules = determine_th_modules(ghc_options, args.source_prefix)
     package_prefixes = calc_package_prefixes(args.package)
     module_mapping, module_graph, package_deps, toolchain_deps = interpret_ghc_depends(
         ghc_depends, args.source_prefix, package_prefixes, toolchain_packages)
@@ -114,6 +115,40 @@ __TH_EXTENSIONS = ["TemplateHaskell", "TemplateHaskellQuotes", "QuasiQuotes"]
 def uses_th(opts):
     """Determine if a Template Haskell extension is enabled."""
     return any([f"-X{ext}" in opts for ext in __TH_EXTENSIONS])
+
+
+def fix_ghc_args(ghc_args, toolchain_packages):
+    """Replaces -package flags by -package-id where applicable.
+
+    Packages that have hidden internal packages cause failures of the form:
+
+        Could not load module ‘Data.Attoparsec.Text’.
+        It is a member of the hidden package ‘attoparsec-0.14.4’.
+
+    This can be avoided by specifying the corresponding packages by package-id
+    rather than package name.
+
+    The toolchain libraries catalog tracks a mapping from package name to
+    package id. We apply it here to any toolchain library dependencies.
+    """
+    result = []
+    mapping = toolchain_packages["by-package-name"]
+
+    args_iter = iter(ghc_args)
+    for arg in args_iter:
+        if arg == "-package":
+            package_name = next(args_iter)
+            if package_name is None:
+                raise RuntimeError("Missing package name argument for -package flag")
+
+            if (package_id := mapping.get(package_name, None)) is not None:
+                result.extend(["-package-id", package_id])
+            else:
+                result.extend(["-package", package_name])
+        else:
+            result.append(arg)
+
+    return result
 
 
 def run_ghc_depends(ghc, ghc_args, sources):

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -158,8 +158,8 @@ def lookup_toolchain_dep(module_dep, toolchain_packages):
         if (layer := layer.get(part)) is None:
             return None
 
-        if (pkgname := layer.get("//pkgname")) is not None:
-            return pkgname
+        if (pkgid := layer.get("//pkgid")) is not None:
+            return pkgid
 
 
 def lookup_package_dep(module_dep, package_prefixes):

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -153,7 +153,7 @@ def calc_package_prefixes(package_specs):
 
 def lookup_toolchain_dep(module_dep, toolchain_packages):
     module_path = Path(module_dep)
-    layer = toolchain_packages
+    layer = toolchain_packages["by-import-dirs"]
     for part in module_path.parts:
         if (layer := layer.get(part)) is None:
             return None

--- a/haskell/tools/generate_toolchain_library_catalog.py
+++ b/haskell/tools/generate_toolchain_library_catalog.py
@@ -3,7 +3,7 @@
 """Helper script to generate a mapping from interface paths to toolchain library names.
 
 The result is a JSON object with the following fields:
-* `by-import-dirs`: A trie mapping import directory prefixes to package names. Encoded as nested dictionaries with leafs denoted by the special key `//pkgname`.
+* `by-import-dirs`: A trie mapping import directory prefixes to package names. Encoded as nested dictionaries with leafs denoted by the special key `//pkgid`.
 """
 
 import argparse
@@ -93,7 +93,7 @@ def _construct_import_path_trie(packages):
             for part in Path(import_dir).parts:
                 layer = layer.setdefault(part, {})
 
-            layer["//pkgname"] = package["name"]
+            layer["//pkgid"] = package["id"]
 
     return result
 

--- a/haskell/tools/generate_toolchain_library_catalog.py
+++ b/haskell/tools/generate_toolchain_library_catalog.py
@@ -61,15 +61,23 @@ def _parse_ghc_pkg_dump(lines):
 
             if key == "name":
                 current_key = "name"
-                current_package["name"] = value
+                if value:
+                    current_package["name"] = value
+            elif key == "id":
+                current_key = "id"
+                if value:
+                    current_package["id"] = value
             elif key == "import-dirs":
                 current_key = "import-dirs"
                 if value:
                     current_package.setdefault("import-dirs", []).append(value)
             else:
                 current_key = None
-        elif current_key == "import-dirs" and line.strip():
-            current_package.setdefault("import-dirs", []).append(line.strip())
+        elif line.strip():
+            if current_key in ["name", "id"]:
+                current_package[current_key] = line.strip()
+            elif current_key == "import-dirs":
+                current_package.setdefault("import-dirs", []).append(line.strip())
 
     if current_package:
         yield current_package


### PR DESCRIPTION
Closes https://github.com/MercuryTechnologies/the-culture-repo/issues/131

Toolchain library dependencies are now specified on the GHC command-line using `-package-id` flags instead of `-package` flags. This resolves issues where GHC reports module dependencies from hidden package, despite these packages being listed on the command line using `-package` flags.

We also need to use `-package-id` flags when generating the dependency metadata JSON file. Unfortunately, doing this cleanly when we generate the flags in Starlark is not quite as easy as at the build stage. So, this PR instead patches the GHC flags within the Python script that invokes GHC -M. I'd like to find a better way to do this, but will leave this open for a future improvement.

- **Parse package-id field**
- **Track package-id for toolchain libraries**
- **store mapping from package name to package id**
- **[workaround] MD: Replace -package with -package-id**
- **Specify toolchain_deps using -package-id**
