### PR TITLE
Do not set `GHC_PACKAGE_PATH` when it is empty

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -482,7 +482,7 @@ def _make_package(
         ]),
         category = "haskell_package_" + artifact_suffix.replace("-", "_"),
         identifier = "empty" if use_empty_lib else "final",
-        env = {"GHC_PACKAGE_PATH": ghc_package_path},
+        env = {"GHC_PACKAGE_PATH": ghc_package_path} if db_deps else {},
     )
 
     return db


### PR DESCRIPTION
Otherwise this led to a spurious error like this:
```
Local command returned non-zero exit code 1
Reproduce locally: `env -- 'BUCK_SCRATCH_PATH=buck-out/v2/tmp/root/904931f735703749/backend/src/__backend_infra__/haskel ...<omitted>... nfra__/db-static buck-out/v2/gen/root/904931f735703749/backend/src/__backend_infra__/pkg-static.conf (run `buck2 log what-failed` to get the full command)`
stdout:
stderr:
WARNING: cache does not exist: ./package.cache
ghc will fail to read this package db. Use 'ghc-pkg recache' to fix.
ghc-pkg-9.8.2: "the input" (line 14, column 1):
unexpected operator "#"
expecting field or section name
```
