### PR TITLE
Add hidden inputs to final ghci script

### DIFF
--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -726,7 +726,7 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
         "__{}__".format(ctx.label.name),
         output_artifacts,
     )
-    run = cmd_args(final_ghci_script).hidden(outputs)
+    run = cmd_args(final_ghci_script, hidden=ctx.attrs.ghci_bin_dep.get(RunInfo) or []).hidden(outputs)
 
     return [
         DefaultInfo(default_outputs = [root_output_dir]),


### PR DESCRIPTION
This is needed when the script is referring to another output that depends on
other artifacts at runtime.
