### PR TITLE
Recompilation avoidance on -package-db arguments

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -64,15 +64,23 @@ def _compiled_module_project_as_dyn_objects_dot_o(mod: CompiledModuleInfo) -> cm
 
 def _compiled_module_reduce_as_package_deps(children: list[dict[str, None]], mod: CompiledModuleInfo | None) -> dict[str, None]:
     # TODO[AH] is there a better way to avoid duplicate -package flags?
-    #   Using a project instead would produce duplicates.
+    #   Using a projection instead would produce duplicates.
     result = {pkg: None for pkg in mod.package_deps} if mod else {}
+    for child in children:
+        result.update(child)
+    return result
+
+def _compiled_module_reduce_as_packagedb_deps(children: list[dict[Artifact, None]], mod: CompiledModuleInfo | None) -> dict[Artifact, None]:
+    # TODO[AH] is there a better way to avoid duplicate package-dbs?
+    #   Using a projection instead would produce duplicates.
+    result = {db: None for db in mod.db_deps} if mod else {}
     for child in children:
         result.update(child)
     return result
 
 def _compiled_module_reduce_as_toolchain_deps(children: list[dict[str, None]], mod: CompiledModuleInfo | None) -> dict[str, None]:
     # TODO[AH] is there a better way to avoid duplicate -package-id flags?
-    #   Using a project instead would produce duplicates.
+    #   Using a projection instead would produce duplicates.
     result = {pkg: None for pkg in mod.toolchain_deps} if mod else {}
     for child in children:
         result.update(child)
@@ -87,6 +95,7 @@ CompiledModuleTSet = transitive_set(
     },
     reductions = {
         "package_deps": _compiled_module_reduce_as_package_deps,
+        "packagedb_deps": _compiled_module_reduce_as_packagedb_deps,
         "toolchain_deps": _compiled_module_reduce_as_toolchain_deps,
     },
 )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -392,7 +392,7 @@ def _common_compile_args(
         modname: str | None = None,
         resolved: None | dict[DynamicValue, ResolvedDynamicValue] = None,
         package_deps: None | dict[str, list[str]] = None,
-        use_empty_lib = True) -> (None | list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
+        use_empty_lib = True) -> (None | list[CompiledModuleTSet], cmd_args, None | ArtifactTag, list[Artifact]):
     toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
 
     compile_args = cmd_args()
@@ -427,49 +427,53 @@ def _common_compile_args(
     if not modname:
         compile_args.add(packages_info.exposed_package_args)
         compile_args.hidden(packages_info.exposed_package_imports)
+        compile_args.add(packages_info.packagedb_args)
 
-    packagedb_tag = ctx.actions.artifact_tag()
+    if modname:
+        packagedb_tag = ctx.actions.artifact_tag()
 
-    # TODO[AH] Avoid duplicates and share identical env files.
-    #   The set of package-dbs can be known at the package level, not just the
-    #   module level. So, we could generate this file outside of the
-    #   dynamic_output action.
-    package_env_file = ctx.actions.declare_output(".".join([
-        ctx.label.name,
-        modname or "pkg",
-        "package-db",
-        output_extensions(link_style, enable_profiling)[1],
-        "env",
-    ]))
-    package_env = cmd_args(
-        "clear-package-db",
-        "global-package-db",
-        delimiter = "\n",
-    )
-    packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
-    package_env.add(cmd_args(
-        packagedb_args,
-        format = "package-db {}",
-    ).relative_to(package_env_file, parent = 1))
-    ctx.actions.write(
-        package_env_file,
-        package_env,
-    )
-    compile_args.add(cmd_args(
-        packagedb_tag.tag_artifacts(package_env_file),
-        prepend = "-package-env",
-        hidden = packagedb_args,
-    ))
+        # TODO[AH] Avoid duplicates and share identical env files.
+        #   The set of package-dbs can be known at the package level, not just the
+        #   module level. So, we could generate this file outside of the
+        #   dynamic_output action.
+        package_env_file = ctx.actions.declare_output(".".join([
+            ctx.label.name,
+            modname or "pkg",
+            "package-db",
+            output_extensions(link_style, enable_profiling)[1],
+            "env",
+        ]))
+        package_env = cmd_args(
+            "clear-package-db",
+            "global-package-db",
+            delimiter = "\n",
+        )
+        packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
+        package_env.add(cmd_args(
+            packagedb_args,
+            format = "package-db {}",
+        ).relative_to(package_env_file, parent = 1))
+        ctx.actions.write(
+            package_env_file,
+            package_env,
+        )
+        compile_args.add(cmd_args(
+            packagedb_tag.tag_artifacts(package_env_file),
+            prepend = "-package-env",
+            hidden = packagedb_args,
+        ))
 
-    dep_file = ctx.actions.declare_output(".".join([
-        ctx.label.name,
-        modname or "pkg",
-        "package-db",
-        output_extensions(link_style, enable_profiling)[1],
-        "dep",
-    ])).as_output()
-    tagged_dep_file = packagedb_tag.tag_artifacts(dep_file)
-    compile_args.add("--buck2-packagedb-dep", tagged_dep_file)
+        dep_file = ctx.actions.declare_output(".".join([
+            ctx.label.name,
+            modname or "pkg",
+            "package-db",
+            output_extensions(link_style, enable_profiling)[1],
+            "dep",
+        ])).as_output()
+        tagged_dep_file = packagedb_tag.tag_artifacts(dep_file)
+        compile_args.add("--buck2-packagedb-dep", tagged_dep_file)
+    else:
+        packagedb_tag = None
 
     if enable_th:
         compile_args.add(packages_info.exposed_package_libs)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -244,7 +244,7 @@ def target_metadata(
     ghc_args.add(package_flag, "base")
     ghc_args.add(cmd_args(toolchain_libs, prepend=package_flag))
     ghc_args.add(cmd_args(packages_info.exposed_package_args))
-    ghc_args.add(packages_info.packagedb_args)
+    ghc_args.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
     ghc_args.add(ctx.attrs.compiler_flags)
 
     md_args = cmd_args(md_gen)
@@ -334,10 +334,9 @@ def get_packages_info(
             # we're using Template Haskell:
             exposed_package_libs.hidden(lib.libs)
 
-    packagedb_args = cmd_args(
-        libs.project_as_args("empty_package_db" if use_empty_lib else "package_db"),
-        prepend = "-package-db"
-    )
+    packagedb_args = cmd_args(libs.project_as_args(
+        "empty_package_db" if use_empty_lib else "package_db",
+    ))
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,
@@ -408,7 +407,7 @@ def _common_compile_args(
     if not modname:
         compile_args.add(packages_info.exposed_package_args)
         compile_args.hidden(packages_info.exposed_package_imports)
-    compile_args.add(packages_info.packagedb_args)
+    compile_args.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
     if enable_th:
         compile_args.add(packages_info.exposed_package_libs)
         if not modname:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -334,8 +334,10 @@ def get_packages_info(
             # we're using Template Haskell:
             exposed_package_libs.hidden(lib.libs)
 
-    packagedb_args = cmd_args()
-    packagedb_args.add(libs.project_as_args("empty_package_db" if use_empty_lib else "package_db"))
+    packagedb_args = cmd_args(
+        libs.project_as_args("empty_package_db" if use_empty_lib else "package_db"),
+        prepend = "-package-db"
+    )
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -431,6 +431,9 @@ def _common_compile_args(
     packagedb_tag = ctx.actions.artifact_tag()
 
     # TODO[AH] Avoid duplicates and share identical env files.
+    #   The set of package-dbs can be known at the package level, not just the
+    #   module level. So, we could generate this file outside of the
+    #   dynamic_output action.
     package_env_file = ctx.actions.declare_output(".".join([
         ctx.label.name,
         modname or "pkg",

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -424,8 +424,9 @@ def _common_compile_args(
         "global-package-db",
         delimiter = "\n",
     )
+    packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
     package_env.add(cmd_args(
-        packages_info.packagedb_args,
+        packagedb_args,
         format = "package-db {}",
     ).relative_to(package_env_file, parent = 1))
     ctx.actions.write(
@@ -435,7 +436,7 @@ def _common_compile_args(
     compile_args.add(cmd_args(
         packagedb_tag.tag_artifacts(package_env_file),
         prepend = "-package-env",
-        hidden = packages_info.packagedb_args,
+        hidden = packagedb_args,
     ))
 
     dep_file = ctx.actions.declare_output(".".join([

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -408,6 +408,7 @@ def _common_compile_args(
         compile_args.add(packages_info.exposed_package_args)
         compile_args.hidden(packages_info.exposed_package_imports)
 
+    # TODO[AH] Avoid duplicates and share identical env files.
     package_env_file = ctx.actions.declare_output(".".join([
         ctx.label.name,
         modname or "pkg",

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -315,8 +315,6 @@ def get_packages_info(
     exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
 
-    packagedb_args = cmd_args()
-
     if resolved != None and package_deps != None:
         exposed_package_modules = []
 
@@ -336,6 +334,7 @@ def get_packages_info(
             # we're using Template Haskell:
             exposed_package_libs.hidden(lib.libs)
 
+    packagedb_args = cmd_args()
     packagedb_args.add(libs.project_as_args("empty_package_db" if use_empty_lib else "package_db"))
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -213,6 +213,33 @@ _toolchain_library_catalog = anon_rule(
     }
 )
 
+def _package_env_file_impl(ctx: AnalysisContext) -> list[Provider]:
+    package_env_file = ctx.actions.declare_output("package-db.env")
+    package_env = cmd_args(
+        "clear-package-db",
+        "global-package-db",
+        delimiter = "\n",
+    )
+    package_env.add(cmd_args(
+        ctx.attrs.package_dbs,
+        format = "package-db {}",
+    ).relative_to(package_env_file, parent = 1))
+    ctx.actions.write(
+        package_env_file,
+        package_env,
+    )
+    return [DefaultInfo(default_output = package_env_file)]
+
+_package_env_file = anon_rule(
+    impl = _package_env_file_impl,
+    attrs = {
+        "package_dbs": attrs.list(attrs.source()),
+    },
+    artifact_promise_mappings = {
+        "env_file": lambda x: x[DefaultInfo].default_outputs[0],
+    },
+)
+
 def target_metadata(
         ctx: AnalysisContext,
         *,
@@ -428,34 +455,15 @@ def _common_compile_args(
         compile_args.add(packages_info.exposed_package_args)
         compile_args.hidden(packages_info.exposed_package_imports)
 
-    packagedb_tag = ctx.actions.artifact_tag()
+    packagedb_env_file = ctx.actions.anon_target(_package_env_file, {
+        "package_dbs": list(packages_info.packagedb_args.inputs),
+    }).artifact("env_file")
 
-    # TODO[AH] Avoid duplicates and share identical env files.
-    package_env_file = ctx.actions.declare_output(".".join([
-        ctx.label.name,
-        modname or "pkg",
-        "package-db",
-        output_extensions(link_style, enable_profiling)[1],
-        "env",
-    ]))
-    package_env = cmd_args(
-        "clear-package-db",
-        "global-package-db",
-        delimiter = "\n",
-    )
-    packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
-    package_env.add(cmd_args(
-        packagedb_args,
-        format = "package-db {}",
-    ).relative_to(package_env_file, parent = 1))
-    ctx.actions.write(
-        package_env_file,
-        package_env,
-    )
+    packagedb_tag = ctx.actions.artifact_tag()
     compile_args.add(cmd_args(
-        packagedb_tag.tag_artifacts(package_env_file),
+        packagedb_tag.tag_artifacts(packagedb_env_file),
         prepend = "-package-env",
-        hidden = packagedb_args,
+        hidden = packagedb_tag.tag_artifacts(packages_info.packagedb_args),
     ))
 
     dep_file = ctx.actions.declare_output(".".join([

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -427,7 +427,7 @@ def _common_compile_args(
     if not modname:
         compile_args.add(packages_info.exposed_package_args)
         compile_args.hidden(packages_info.exposed_package_imports)
-        compile_args.add(packages_info.packagedb_args)
+        compile_args.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
 
     if modname:
         packagedb_tag = ctx.actions.artifact_tag()

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -644,6 +644,8 @@ def _compile_module(
         compile_cmd.add(cmd_args(dependency_modules.reduce("package_deps").keys(), prepend = "-package"))
         compile_cmd.add(cmd_args(dependency_modules.reduce("toolchain_deps").keys(), prepend = "-package-id"))
 
+    compile_cmd.add(cmd_args(dependency_modules.reduce("packagedb_deps").keys(), prepend = "--buck2-package-db"))
+
     dep_file = ctx.actions.declare_output("dep-{}_{}".format(module_name, artifact_suffix)).as_output()
 
     tagged_dep_file = abi_tag.tag_artifacts(dep_file)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -425,15 +425,14 @@ def _common_compile_args(
         packages_info.packagedb_args,
         format = "package-db {}",
     ).relative_to(package_env_file, parent = 1))
-    _, package_env_inputs = ctx.actions.write(
+    ctx.actions.write(
         package_env_file,
         package_env,
-        allow_args = True,
     )
     compile_args.add(cmd_args(
         package_env_file,
         prepend = "-package-env",
-        hidden = package_env_inputs,
+        hidden = packages_info.packagedb_args,
     ))
 
     if enable_th:

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1048,7 +1048,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     link.add("-hide-all-packages")
     link.add(cmd_args(toolchain_libs, prepend = "-package"))
     link.add(cmd_args(packages_info.exposed_package_args))
-    link.add(packages_info.packagedb_args)
+    link.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
     link.add("-o", output.as_output())
     link.add(haskell_toolchain.linker_flags)
     link.add(ctx.attrs.linker_flags)

--- a/haskell/library_info.bzl
+++ b/haskell/library_info.bzl
@@ -49,10 +49,10 @@ HaskellLibraryInfo = record(
 )
 
 def _project_as_package_db(lib: HaskellLibraryInfo):
-  return cmd_args("-package-db", lib.db)
+  return cmd_args(lib.db)
 
 def _project_as_empty_package_db(lib: HaskellLibraryInfo):
-  return cmd_args("-package-db", lib.empty_db)
+  return cmd_args(lib.empty_db)
 
 HaskellLibraryInfoTSet = transitive_set(
     args_projections = {

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -31,6 +31,13 @@ def main():
         help="Path to the dep file.",
     )
     parser.add_argument(
+        "--buck2-package-db",
+        required=False,
+        nargs="*",
+        default=[],
+        help="Path to a package db that is used during the module compilation",
+    )
+    parser.add_argument(
         "--ghc", required=True, type=str, help="Path to the Haskell compiler GHC."
     )
     parser.add_argument(
@@ -61,7 +68,10 @@ def main():
     # write an empty dep file, to signal that all tagged files are unused
     try:
         with open(args.buck2_packagedb_dep, "w") as f:
-            f.write("\n")
+            for db in args.buck2_package_db:
+                f.write(db + "\n")
+            if not args.buck2_package_db:
+                f.write("\n")
 
     except Exception as e:
         # remove incomplete dep file

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -26,6 +26,11 @@ def main():
         help="Path to the dep file.",
     )
     parser.add_argument(
+        "--buck2-packagedb-dep",
+        required=True,
+        help="Path to the dep file.",
+    )
+    parser.add_argument(
         "--ghc", required=True, type=str, help="Path to the Haskell compiler GHC."
     )
     parser.add_argument(
@@ -51,6 +56,16 @@ def main():
     except Exception as e:
         # remove incomplete dep file
         os.remove(args.buck2_dep)
+        raise e
+
+    # write an empty dep file, to signal that all tagged files are unused
+    try:
+        with open(args.buck2_packagedb_dep, "w") as f:
+            f.write("\n")
+
+    except Exception as e:
+        # remove incomplete dep file
+        os.remove(args.buck2_packagedb_dep)
         raise e
 
 


### PR DESCRIPTION
Expands recompilation avoidance to changes in the transitive package dependency graph that don't impact a given module.

Consider the following targets and assume that we built module `A`.
```
haskell_library(
    name = "a",
    srcs = ["A.hs"],  # imports B1
    deps = [":b"],
)

haskell_library(
    name = "b",
    srcs = [
        "B1.hs",
        "B2.hs",
    ],
)
```

Assume that we change the targets as follows:
```
haskell_library(
    name = "a",
    srcs = ["A.hs"],  # imports B1
    deps = [":b"],
)

haskell_library(
    name = "b",
    srcs = [
        "B1.hs",
        "B2.hs",  # imports C
    ],
    deps = [":c"],
)
haskell_library(
    name = "c",
    srcs = ["C.hs"],
)
```

If we now issue a build of module `A` again then `A` should ideally not be recompiled but instead fetched from cache, because it does not transitively depend on the newly added package dependency `c` and module dependency `C`.

Previously this was not the case because adding the dependency on `c` to package `b` still impacts to the set of `-package-db` flags when compiling module `A`.

With this PR this recompilation is avoided. It uses a dep-file to tag the full transitive set of `-package-db` flags (now passed via package environment file) and unused package-dbs as unused. Only the `-package-db` flags and files of actual transitive dependencies of module `A` are marked use used dependencies.

- **move variable assignments together**
- **No implicity -package-db prefix**
- **Push the -package-db prefix up**
- **define a package-env file for the package-db flags**
- **todo note**
- **Fix missing package_db inputs**
- **Add dep file for package-db flags**
- **Tag all package-db inputs (over-eager)**
- **track module package-db dependencies**
- **projection to access module package db deps**
- **Track used package-dbs in the dep file**
- **FAILS deduplicate .env via anon-target**
- **Revert "FAILS deduplicate .env via anon-target"**
- **Expand todo note**
