### PR TITLE
Remove clear-package-db from package-env file

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -443,11 +443,7 @@ def _common_compile_args(
             output_extensions(link_style, enable_profiling)[1],
             "env",
         ]))
-        package_env = cmd_args(
-            "clear-package-db",
-            "global-package-db",
-            delimiter = "\n",
-        )
+        package_env = cmd_args(delimiter = "\n")
         packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
         package_env.add(cmd_args(
             packagedb_args,


### PR DESCRIPTION
That bit was taken from the GHC docs but interferes with the changes introduced in https://github.com/MercuryTechnologies/the-culture-repo/pull/157.
