### PR TITLE
Use individual package DBs for nix haskell libs

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -568,6 +568,10 @@ def _build_haskell_lib(
             ),
         )
 
+        # TODO[CB] use individual package db for each package
+        if haskell_toolchain.packages:
+            link.add("-package-db", haskell_toolchain.packages.package_db)
+
         link.add(compiled.objects)
 
         infos = get_link_args_for_strategy(

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -521,6 +521,8 @@ def _build_haskell_lib(
         non_profiling_hlib: [HaskellLibBuildOutput, None] = None) -> HaskellLibBuildOutput:
     linker_info = ctx.attrs._cxx_toolchain[CxxToolchainInfo].linker_info
 
+    toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
+
     # Link the objects into a library
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
@@ -674,6 +676,7 @@ def _build_haskell_lib(
         version = "1.0.0",
         is_prebuilt = False,
         profiling_enabled = enable_profiling,
+        dependencies = toolchain_libs,
     )
 
     return HaskellLibBuildOutput(

--- a/haskell/library_info.bzl
+++ b/haskell/library_info.bzl
@@ -46,6 +46,8 @@ HaskellLibraryInfo = record(
     version = str,
     is_prebuilt = bool,
     profiling_enabled = bool,
+    # Package dependencies
+    dependencies = list[str],
 )
 
 def _project_as_package_db(lib: HaskellLibraryInfo):

--- a/haskell/library_info.bzl
+++ b/haskell/library_info.bzl
@@ -5,6 +5,8 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//utils:utils.bzl", "flatten", "dedupe_by_value")
+
 # If the target is a haskell library, the HaskellLibraryProvider
 # contains its HaskellLibraryInfo. (in contrast to a HaskellLinkInfo,
 # which contains the HaskellLibraryInfo for all the transitive
@@ -56,9 +58,18 @@ def _project_as_package_db(lib: HaskellLibraryInfo):
 def _project_as_empty_package_db(lib: HaskellLibraryInfo):
   return cmd_args(lib.empty_db)
 
+def _get_package_deps(children: list[list[str]], lib: HaskellLibraryInfo | None):
+    flatted = flatten(children)
+    if lib:
+        flatted.extend(lib.dependencies)
+    return dedupe_by_value(flatted)
+
 HaskellLibraryInfoTSet = transitive_set(
     args_projections = {
         "package_db": _project_as_package_db,
         "empty_package_db": _project_as_empty_package_db,
+    },
+    reductions = {
+        "packages": _get_package_deps,
     },
 )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -50,3 +50,9 @@ HaskellToolchainLibrary = provider(
 HaskellPackagesInfo = record(
     package_db = Artifact,
 )
+
+HaskellPackageDbTSet = transitive_set()
+
+DynamicHaskellPackageDbInfo = provider(fields = {
+    "packages": dict[str, HaskellPackageDbTSet],
+})

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -37,6 +37,7 @@ HaskellToolchainInfo = provider(
         "ghci_packager": provider_field(typing.Any, default = None),
         "cache_links": provider_field(typing.Any, default = None),
         "script_template_processor": provider_field(typing.Any, default = None),
+        "packages": provider_field(typing.Any, default = None),
     },
 )
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -52,7 +52,14 @@ HaskellPackagesInfo = record(
     dynamic = DynamicValue,
 )
 
-HaskellPackageDbTSet = transitive_set()
+def _haskell_package_info_as_package_db(p: Artifact):
+    return cmd_args(p)
+
+HaskellPackageDbTSet = transitive_set(
+    args_projections = {
+        "package_db": _haskell_package_info_as_package_db,
+    }
+)
 
 DynamicHaskellPackageDbInfo = provider(fields = {
     "packages": dict[str, HaskellPackageDbTSet],

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -46,3 +46,7 @@ HaskellToolchainLibrary = provider(
         "name": provider_field(str),
     },
 )
+
+HaskellPackagesInfo = record(
+    package_db = Artifact,
+)

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -49,6 +49,7 @@ HaskellToolchainLibrary = provider(
 
 HaskellPackagesInfo = record(
     package_db = Artifact,
+    dynamic = DynamicValue,
 )
 
 HaskellPackageDbTSet = transitive_set()

--- a/haskell/tools/generate_toolchain_library_catalog.py
+++ b/haskell/tools/generate_toolchain_library_catalog.py
@@ -27,16 +27,21 @@ def main():
         required=True,
         type=str,
         help="Path to the Haskell compiler's ghc-pkg utilty.")
+    parser.add_argument(
+        "--package-db",
+        required=False,
+        type=str,
+        help="Path to the package db including all haskell libraries.")
     args = parser.parse_args()
 
-    with subprocess.Popen(_ghc_pkg_command(args.ghc_pkg), stdout=subprocess.PIPE, text=True) as proc:
+    with subprocess.Popen(_ghc_pkg_command(args.ghc_pkg, args.package_db), stdout=subprocess.PIPE, text=True) as proc:
         packages = list(_parse_ghc_pkg_dump(proc.stdout))
         result = _construct_package_mappings(packages)
 
     json.dump(result, args.output)
 
 
-def _ghc_pkg_command(ghc_pkg):
+def _ghc_pkg_command(ghc_pkg, package_db):
     return [
         ghc_pkg,
         "dump",
@@ -44,7 +49,7 @@ def _ghc_pkg_command(ghc_pkg):
         "--no-user-package-db",
         "--simple-output",
         "--expand-pkgroot",
-    ]
+    ] + (["--package-db", package_db] if package_db else [])
 
 
 def _parse_ghc_pkg_dump(lines):


### PR DESCRIPTION
This changes the handling of package db's for haskell targets by using a tset to maintain a dependency tree for nix haskell packages.

For a haskell module, `-package-db` flags are passed for each of the required haskell toolchain libraries including their dependent package dbs.

This way only the the minimally required haskell nix packages are build by buck2 that are needed for a specific haskell target.

- Cleanup _common_compile_args
- Add `packages` field to `HaskellToolchainInfo`
- Add `HaskellPackagesInfo` record
- Use package db from toolchain packages info
- Add `HaskellPackagesInfoTSet` and a dynamic provider
- Add `dynamic` field to `HaskellPackagesInfo`
- Add package dependencies to HaskellLibraryInfo
- Add `packages` reduction for HaskellLibraryInfoTSet
- Add `package_db` projection to HaskellPackageDbTSet`
- Use individual package dbs from resolved package db info
- Pass resolved package info to get_packages_info for metadata
- Use individual package db in haskell_binary rule
- Use individual package db in haskell_library rule
