### PR TITLE
remove unused branches

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -440,7 +440,7 @@ def _common_compile_args(
         link_style: LinkStyle,
         enable_profiling: bool,
         enable_th: bool,
-        pkgname: str,
+        pkgname: str | None,
         modname: str,
         resolved: dict[DynamicValue, ResolvedDynamicValue],
         package_deps: dict[str, list[str]]) -> (None | list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
@@ -519,7 +519,8 @@ def _common_compile_args(
     pre_args = pre.set.project_as_args("args")
     compile_args.add(cmd_args(pre_args, format = "-optP={}"))
 
-    compile_args.add(["-this-unit-id", pkgname])
+    if pkgname:
+        compile_args.add(["-this-unit-id", pkgname])
 
     module_tsets = packages_info.exposed_package_modules
 
@@ -535,7 +536,7 @@ def _compile_module_args(
         enable_th: bool,
         outputs: dict[Artifact, Artifact],
         resolved: dict[DynamicValue, ResolvedDynamicValue],
-        pkgname: str,
+        pkgname: str | None,
         package_deps: dict[str, list[str]]) -> CompileArgsInfo:
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -113,7 +113,7 @@ CompileResultInfo = record(
     stubs = field(Artifact),
     hashes = field(list[Artifact]),
     producing_indices = field(bool),
-    module_tsets = field(None | list[CompiledModuleTSet] | DynamicValue),
+    module_tsets = field(list[CompiledModuleTSet] | DynamicValue),
 )
 
 CompileArgsInfo = record(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -458,6 +458,7 @@ def _compile_module_args(
     if enable_haddock:
         compile_cmd.add("-haddock")
 
+    # These compiler arguments can be passed in a response file.
     compile_args = cmd_args()
     compile_args.add("-no-link", "-i")
     compile_args.add("-hide-all-packages")

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -539,8 +539,8 @@ def _compile_module_args(
         enable_th: bool,
         outputs: dict[Artifact, Artifact],
         resolved: dict[DynamicValue, ResolvedDynamicValue],
-        pkgname = None,
-        package_deps: None | dict[str, list[str]] = None) -> CompileArgsInfo:
+        pkgname: str,
+        package_deps: dict[str, list[str]]) -> CompileArgsInfo:
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
     compile_cmd = cmd_args()

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -440,11 +440,10 @@ def _common_compile_args(
         link_style: LinkStyle,
         enable_profiling: bool,
         enable_th: bool,
-        pkgname: str | None,
+        pkgname: str,
         modname: str,
-        resolved: None | dict[DynamicValue, ResolvedDynamicValue] = None,
-        package_deps: None | dict[str, list[str]] = None,
-        use_empty_lib = True) -> (None | list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
+        resolved: dict[DynamicValue, ResolvedDynamicValue],
+        package_deps: dict[str, list[str]]) -> (None | list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
     compile_args = cmd_args()
     compile_args.add("-no-link", "-i")
     compile_args.add("-hide-all-packages")
@@ -467,7 +466,7 @@ def _common_compile_args(
         link_style,
         specify_pkg_version = False,
         enable_profiling = enable_profiling,
-        use_empty_lib = use_empty_lib,
+        use_empty_lib = True,
         resolved = resolved,
         package_deps = package_deps,
     )
@@ -513,8 +512,6 @@ def _common_compile_args(
 
     if enable_th:
         compile_args.add(packages_info.exposed_package_libs)
-        if not modname:
-            compile_args.hidden(packages_info.exposed_package_objects)
 
     # Add args from preprocess-able inputs.
     inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
@@ -522,8 +519,7 @@ def _common_compile_args(
     pre_args = pre.set.project_as_args("args")
     compile_args.add(cmd_args(pre_args, format = "-optP={}"))
 
-    if pkgname:
-        compile_args.add(["-this-unit-id", pkgname])
+    compile_args.add(["-this-unit-id", pkgname])
 
     module_tsets = packages_info.exposed_package_modules
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -443,7 +443,7 @@ def _common_compile_args(
         pkgname: str | None,
         modname: str,
         resolved: dict[DynamicValue, ResolvedDynamicValue],
-        package_deps: dict[str, list[str]]) -> (None | list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
+        package_deps: dict[str, list[str]]) -> (list[CompiledModuleTSet], cmd_args, ArtifactTag, list[Artifact]):
     compile_args = cmd_args()
     compile_args.add("-no-link", "-i")
     compile_args.add("-hide-all-packages")


### PR DESCRIPTION
Remove unused `None` cases and inline `_common_compile_args`. This function was only used in one place and the separation caused some friction.

- **Remove None options on _compile_module_args**
- **Remove None options on _common_compile_args**
- **Fix: pkgname can be None**
- **Remove None from _common_compile_args return type**
- **Remove None from CompileResultInfo**
- **Inline _common_compile_args**
- **Document compile_args vs. compile_cmd**
