### PR TITLE
Add binaries from haskell packages to PATH

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -24,6 +24,9 @@ def _deps_arg():
      from which this rules sources import modules or native linkable rules exporting symbols
      this rules sources call into.
 """),
+        "srcs_deps": attrs.dict(attrs.source(), attrs.list(attrs.source()), default = {}, doc = """
+    Allows to declare dependencies for sources manually, additionally to the dependencies automatically detected.
+        """),
     }
 
 def _compiler_flags_arg():

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -556,13 +556,12 @@ def _compile_module(
     if aux_deps:
         compile_args_for_file.hidden(aux_deps)
 
-    for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
-        # hs-boot files aren't expected to be an argument to compiler but does need
-        # to be included in the directory of the associated src file
-        # TODO(ah) We should not indiscriminately include all non-hs sources,
-        #   but only those that this module actually depends on.
-        if not is_haskell_src(path):
-            compile_args_for_file.hidden(src)
+    non_haskell_sources = [src for (path, src) in srcs_to_pairs(ctx.attrs.srcs) if not is_haskell_src(path)]
+
+    if non_haskell_sources:
+        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(ctx.label))
+
+        compile_args_for_file.hidden(non_haskell_sources)
 
     if haskell_toolchain.use_argsfile:
         argsfile = ctx.actions.declare_output(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -551,6 +551,11 @@ def _compile_module(
         compile_args_for_file.add("-dynohi", his[1].as_output())
 
     compile_args_for_file.add(module.source)
+
+    aux_deps = ctx.attrs.srcs_deps.get(module.source)
+    if aux_deps:
+        compile_args_for_file.hidden(aux_deps)
+
     for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
         # hs-boot files aren't expected to be an argument to compiler but does need
         # to be included in the directory of the associated src file

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -246,9 +246,6 @@ def target_metadata(
 
     def get_metadata(ctx, _artifacts, resolved, outputs, catalog=catalog):
 
-        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
-        package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
-
         # Add -package-db and -package/-expose-package flags for each Haskell
         # library dependency.
 
@@ -265,15 +262,9 @@ def target_metadata(
         ghc_args.add("-hide-all-packages")
         ghc_args.add(package_flag, "base")
 
-        package_dbs = ctx.actions.tset(
-            HaskellPackageDbTSet,
-            children = [package_db[name] for name in toolchain_libs if name in package_db]
-        )
-
         ghc_args.add(cmd_args(toolchain_libs, prepend=package_flag))
         ghc_args.add(cmd_args(packages_info.exposed_package_args))
         ghc_args.add(cmd_args(packages_info.packagedb_args, prepend = "-package-db"))
-        ghc_args.add(cmd_args(package_dbs.project_as_args("package_db"), prepend="-package-db"))
         ghc_args.add(ctx.attrs.compiler_flags)
 
         md_args = cmd_args(md_gen)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -523,8 +523,6 @@ def _build_haskell_lib(
         non_profiling_hlib: [HaskellLibBuildOutput, None] = None) -> HaskellLibBuildOutput:
     linker_info = ctx.attrs._cxx_toolchain[CxxToolchainInfo].linker_info
 
-    toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
-
     # Link the objects into a library
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -52,12 +52,21 @@ HaskellPackagesInfo = record(
     dynamic = DynamicValue,
 )
 
-def _haskell_package_info_as_package_db(p: Artifact):
-    return cmd_args(p)
+HaskellPackage = record(
+    db = Artifact,
+    path = Artifact,
+)
+
+def _haskell_package_info_as_package_db(p: HaskellPackage):
+    return cmd_args(p.db)
+
+def _haskell_package_info_as_package_path(p: HaskellPackage):
+    return cmd_args(p.path)
 
 HaskellPackageDbTSet = transitive_set(
     args_projections = {
         "package_db": _haskell_package_info_as_package_db,
+        "path": _haskell_package_info_as_package_path,
     }
 )
 

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -46,12 +46,24 @@ def main():
         type=Path,
         help="Output path of the abi file to create.",
     )
+    parser.add_argument(
+        "--bin-path",
+        type=Path,
+        action="append",
+        default=[],
+        help="Add given path to PATH.",
+    )
 
     args, ghc_args = parser.parse_known_args()
 
     cmd = [args.ghc] + ghc_args
 
-    subprocess.check_call(cmd)
+    aux_paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
+    env = os.environ.copy()
+    path = env.get("PATH", "")
+    env["PATH"] = os.pathsep.join([path] + aux_paths)
+
+    subprocess.check_call(cmd, env=env)
 
     recompute_abi_hash(args.ghc, args.abi_out)
 


### PR DESCRIPTION
- Remove duplicate variable
- Remove superfluous `-package-db` flags passed to ghc
- Keep track of the path for each haskell package db
- Add `--nix-pkg` argument to `ghc_wrapper.py` and `generate_target_metadata.py`
- Pass `--nix-pkg` flag for each direct toolchain library dependency
- Allow to declare dependencies for haskell sources manually