### PR TITLE
Inline _compile_module_args

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -461,18 +461,15 @@ def _compile_module(
 
     # ------------------------------------------------------------
 
-    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-
-    compile_cmd_ = cmd_args()
-    compile_cmd_.add(haskell_toolchain.compiler_flags)
+    compile_cmd.add(haskell_toolchain.compiler_flags)
 
     # Some rules pass in RTS (e.g. `+RTS ... -RTS`) options for GHC, which can't
     # be parsed when inside an argsfile.
-    compile_cmd_.add(ctx.attrs.compiler_flags)
-    compile_cmd_.add("-c")
+    compile_cmd.add(ctx.attrs.compiler_flags)
+    compile_cmd.add("-c")
 
     if enable_haddock:
-        compile_cmd_.add("-haddock")
+        compile_cmd.add("-haddock")
 
     # These compiler arguments can be passed in a response file.
     compile_args = cmd_args()
@@ -590,7 +587,7 @@ def _compile_module(
             module_tsets = module_tsets_,
         ),
         srcs = srcs,
-        args_for_cmd = compile_cmd_,
+        args_for_cmd = cmd_args(),
         args_for_file = compile_args,
         packagedb_tag = packagedb_tag,
         packagedbs = packages_info.exposed_package_dbs,
@@ -610,8 +607,6 @@ def _compile_module(
         else:
             compile_cmd.add(args.args_for_file)
             compile_cmd.add(args.srcs)
-
-    compile_cmd.add(args.args_for_cmd)
 
     compile_cmd.add(
         cmd_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -490,15 +490,13 @@ def _compile_module(
 
     packagedb_tag = ctx.actions.artifact_tag()
 
-    modname = src_to_module_name(module.source.short_path)
-
     # TODO[AH] Avoid duplicates and share identical env files.
     #   The set of package-dbs can be known at the package level, not just the
     #   module level. So, we could generate this file outside of the
     #   dynamic_output action.
     package_env_file = ctx.actions.declare_output(".".join([
         ctx.label.name,
-        modname or "pkg",
+        module_name or "pkg",
         "package-db",
         output_extensions(link_style, enable_profiling)[1],
         "env",
@@ -521,7 +519,7 @@ def _compile_module(
 
     dep_file = ctx.actions.declare_output(".".join([
         ctx.label.name,
-        modname or "pkg",
+        module_name or "pkg",
         "package-db",
         output_extensions(link_style, enable_profiling)[1],
         "dep",

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -450,8 +450,6 @@ def _compile_module(
     compile_cmd = cmd_args(ctx.attrs._ghc_wrapper[RunInfo])
     compile_cmd.add("--ghc", haskell_toolchain.compiler)
 
-    # ------------------------------------------------------------
-
     compile_cmd.add(haskell_toolchain.compiler_flags)
 
     # Some rules pass in RTS (e.g. `+RTS ... -RTS`) options for GHC, which can't
@@ -567,8 +565,6 @@ def _compile_module(
             compile_args_for_file.hidden(src)
 
     producing_indices = "-fwrite-ide-info" in ctx.attrs.compiler_flags + haskell_toolchain.compiler_flags
-
-    # ------------------------------------------------------------
 
     if haskell_toolchain.use_argsfile:
         argsfile = ctx.actions.declare_output(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -557,14 +557,14 @@ def _compile_module(
         compile_args_for_file.add("-dyno", objects[1].as_output())
         compile_args_for_file.add("-dynohi", his[1].as_output())
 
-    srcs = cmd_args(module.source)
+    compile_args_for_file.add(module.source)
     for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
         # hs-boot files aren't expected to be an argument to compiler but does need
         # to be included in the directory of the associated src file
         # TODO(ah) We should not indiscriminately include all non-hs sources,
         #   but only those that this module actually depends on.
         if not is_haskell_src(path):
-            srcs.hidden(src)
+            compile_args_for_file.hidden(src)
 
     producing_indices = "-fwrite-ide-info" in ctx.attrs.compiler_flags + haskell_toolchain.compiler_flags
 
@@ -574,13 +574,11 @@ def _compile_module(
         argsfile = ctx.actions.declare_output(
             "haskell_compile_" + artifact_suffix + ".argsfile",
         )
-        for_file = cmd_args(compile_args_for_file).add(srcs)
-        ctx.actions.write(argsfile.as_output(), for_file, allow_args = True)
+        ctx.actions.write(argsfile.as_output(), compile_args_for_file, allow_args = True)
         compile_cmd.add(cmd_args(argsfile, format = "@{}"))
-        compile_cmd.hidden(for_file)
+        compile_cmd.hidden(compile_args_for_file)
     else:
         compile_cmd.add(compile_args_for_file)
-        compile_cmd.add(srcs)
 
     compile_cmd.add(
         cmd_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -568,15 +568,6 @@ def _compile_module(
 
     producing_indices = "-fwrite-ide-info" in ctx.attrs.compiler_flags + haskell_toolchain.compiler_flags
 
-    result = CompileResultInfo(
-        objects = objects,
-        hi = his,
-        hashes = [module.hash],
-        stubs = stubs,
-        producing_indices = producing_indices,
-        module_tsets = module_tsets_,
-    )
-
     # ------------------------------------------------------------
 
     if compile_args_for_file:
@@ -604,7 +595,7 @@ def _compile_module(
     # Transitive module dependencies from other packages.
     cross_package_modules = ctx.actions.tset(
         CompiledModuleTSet,
-        children = result.module_tsets,
+        children = module_tsets_,
     )
     # Transitive module dependencies from the same package.
     this_package_modules = [

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -586,7 +586,7 @@ def _compile_module(
             producing_indices = producing_indices,
             module_tsets = module_tsets_,
         ),
-        srcs = srcs,
+        srcs = cmd_args(),
         args_for_cmd = cmd_args(),
         args_for_file = cmd_args(),
         packagedb_tag = packagedb_tag,
@@ -600,13 +600,13 @@ def _compile_module(
             argsfile = ctx.actions.declare_output(
                 "haskell_compile_" + artifact_suffix + ".argsfile",
             )
-            for_file = cmd_args(compile_args_for_file).add(args.srcs)
+            for_file = cmd_args(compile_args_for_file).add(srcs)
             ctx.actions.write(argsfile.as_output(), for_file, allow_args = True)
             compile_cmd.add(cmd_args(argsfile, format = "@{}"))
             compile_cmd.hidden(for_file)
         else:
             compile_cmd.add(compile_args_for_file)
-            compile_cmd.add(args.srcs)
+            compile_cmd.add(srcs)
 
     compile_cmd.add(
         cmd_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -562,8 +562,6 @@ def _compile_module(
         if not is_haskell_src(path):
             compile_args_for_file.hidden(src)
 
-    producing_indices = "-fwrite-ide-info" in ctx.attrs.compiler_flags + haskell_toolchain.compiler_flags
-
     if haskell_toolchain.use_argsfile:
         argsfile = ctx.actions.declare_output(
             "haskell_compile_" + artifact_suffix + ".argsfile",

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -561,6 +561,8 @@ def _compile_module(
     for (path, src) in srcs_to_pairs(ctx.attrs.srcs):
         # hs-boot files aren't expected to be an argument to compiler but does need
         # to be included in the directory of the associated src file
+        # TODO(ah) We should not indiscriminately include all non-hs sources,
+        #   but only those that this module actually depends on.
         if not is_haskell_src(path):
             srcs.hidden(src)
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -543,8 +543,6 @@ def _compile_module(
     if pkgname:
         compile_args_for_file.add(["-this-unit-id", pkgname])
 
-    module_tsets_ = packages_info.exposed_package_modules
-
     objects = [outputs[obj] for obj in module.objects]
     his = [outputs[hi] for hi in module.interfaces]
     stubs = outputs[module.stub_dir]
@@ -595,7 +593,7 @@ def _compile_module(
     # Transitive module dependencies from other packages.
     cross_package_modules = ctx.actions.tset(
         CompiledModuleTSet,
-        children = module_tsets_,
+        children = packages_info.exposed_package_modules,
     )
     # Transitive module dependencies from the same package.
     this_package_modules = [

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -568,18 +568,17 @@ def _compile_module(
 
     # ------------------------------------------------------------
 
-    if compile_args_for_file:
-        if haskell_toolchain.use_argsfile:
-            argsfile = ctx.actions.declare_output(
-                "haskell_compile_" + artifact_suffix + ".argsfile",
-            )
-            for_file = cmd_args(compile_args_for_file).add(srcs)
-            ctx.actions.write(argsfile.as_output(), for_file, allow_args = True)
-            compile_cmd.add(cmd_args(argsfile, format = "@{}"))
-            compile_cmd.hidden(for_file)
-        else:
-            compile_cmd.add(compile_args_for_file)
-            compile_cmd.add(srcs)
+    if haskell_toolchain.use_argsfile:
+        argsfile = ctx.actions.declare_output(
+            "haskell_compile_" + artifact_suffix + ".argsfile",
+        )
+        for_file = cmd_args(compile_args_for_file).add(srcs)
+        ctx.actions.write(argsfile.as_output(), for_file, allow_args = True)
+        compile_cmd.add(cmd_args(argsfile, format = "@{}"))
+        compile_cmd.hidden(for_file)
+    else:
+        compile_cmd.add(compile_args_for_file)
+        compile_cmd.add(srcs)
 
     compile_cmd.add(
         cmd_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -113,7 +113,7 @@ CompileResultInfo = record(
     stubs = field(Artifact),
     hashes = field(list[Artifact]),
     producing_indices = field(bool),
-    module_tsets = field(list[CompiledModuleTSet] | DynamicValue),
+    module_tsets = field(DynamicValue),
 )
 
 PackagesInfo = record(


### PR DESCRIPTION
`_compile_module_args` was only used once and did no longer properly encapsulate the generation of compiler args for module compilation.

Inlining the function revealed several opportunities to remove duplicate code.

A possible next step is to factor out arguments that are shared across all modules and generate them outside of the loop over modules.

- **Inline _compile_module_args**
- **Remove duplicate compile_cmd object**
- **Inline compile_args_for_file**
- **Remove indirection for srcs**
- **Remove CompileArgsInfo**
- **Remove intermediate CompileResultInfo**
- **Remove unused field type variant**
- **inline packages_info.exposed_package_modules**
- **Remove redundant branch**
- **TODO note**
- **Remove redundant intermediate variable**
- **remove inline markers**
- **remove redundant modname**
- **Remove unused variable**
