### PR TITLE
Split per-module and per-package packages info

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -549,7 +549,7 @@ def _compile_module(
         exposed_package_objects = exposed_package_objects,
         exposed_package_libs = cmd_args(),
         exposed_package_args = exposed_package_args,
-        exposed_package_dbs = exposed_package_dbs,
+        exposed_package_dbs = [],
         packagedb_args = cmd_args(),
         transitive_deps = libs,
     )
@@ -714,7 +714,7 @@ def _compile_module(
             dyn_object_dot_o = dyn_object_dot_o,
             package_deps = package_deps.keys(),
             toolchain_deps = toolchain_deps,
-            db_deps = packages_info.exposed_package_dbs,
+            db_deps = exposed_package_dbs,
         ),
         children = [cross_package_modules] + this_package_modules,
     )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -486,8 +486,6 @@ def _compile_module(
     #    package_deps = package_deps,
     #)
 
-    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-
     # Collect library dependencies. Note that these don't need to be in a
     # particular order.
     direct_deps_link_info = attr_deps_haskell_link_infos(ctx)
@@ -498,14 +496,12 @@ def _compile_module(
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
-    exposed_package_modules = None
+    exposed_package_modules = []
     exposed_package_imports = []
     exposed_package_objects = []
     exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
-
-    exposed_package_modules = []
 
     for lib in direct_deps_link_info:
         info = lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
@@ -528,7 +524,6 @@ def _compile_module(
         enable_profiling,
     )
 
-    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
     pkg_deps = resolved[haskell_toolchain.packages.dynamic]
     package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -542,9 +542,7 @@ def _compile_module(
 
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:
-        pkg_name = lib.name
-
-        exposed_package_args.add(package_flag, pkg_name)
+        exposed_package_args.add(package_flag, lib.name)
 
     packages_info = PackagesInfo(
         exposed_package_modules = exposed_package_modules,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -505,32 +505,22 @@ def _compile_module(
     exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
 
-    if True:
-        exposed_package_modules = []
+    exposed_package_modules = []
 
-        for lib in direct_deps_link_info:
-            info = lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
-            direct = info.value
-            dynamic = direct.dynamic[enable_profiling]
-            dynamic_info = resolved[dynamic][DynamicCompileResultInfo]
+    for lib in direct_deps_link_info:
+        info = lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
+        direct = info.value
+        dynamic = direct.dynamic[enable_profiling]
+        dynamic_info = resolved[dynamic][DynamicCompileResultInfo]
 
-            for mod in package_deps.get(direct.name, []):
-                exposed_package_modules.append(dynamic_info.modules[mod])
+        for mod in package_deps.get(direct.name, []):
+            exposed_package_modules.append(dynamic_info.modules[mod])
 
-            if direct.name in package_deps:
-                db = direct.empty_db if True else direct.db
-                exposed_package_dbs.append(db)
-    else:
-        for lib in libs.traverse():
-            exposed_package_imports.extend(lib.import_dirs[enable_profiling])
-            exposed_package_objects.extend(lib.objects[enable_profiling])
-            # libs of dependencies might be needed at compile time if
-            # we're using Template Haskell:
-            exposed_package_libs.hidden(lib.libs)
+        if direct.name in package_deps:
+            db = direct.empty_db
+            exposed_package_dbs.append(db)
 
-    packagedb_args = cmd_args(libs.project_as_args(
-        "empty_package_db" if True else "package_db",
-    ))
+    packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,
@@ -538,7 +528,7 @@ def _compile_module(
         enable_profiling,
     )
 
-    if haskell_toolchain.packages and True:
+    if haskell_toolchain.packages:
         haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
         pkg_deps = resolved[haskell_toolchain.packages.dynamic]
         package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -454,7 +454,6 @@ def _compile_module(
     packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
 
     # base is special and gets exposed by default
-    package_flag = _package_flag(haskell_toolchain)
     exposed_package_modules = []
     exposed_package_dbs = []
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -446,9 +446,6 @@ def _compile_module(
     # particular order.
     direct_deps_link_info = attr_deps_haskell_link_infos(ctx)
 
-    exposed_package_modules = []
-    exposed_package_dbs = []
-
     libs_by_name = {}
     for lib in direct_deps_link_info:
         info = lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
@@ -461,6 +458,8 @@ def _compile_module(
             modules = dynamic_info.modules,
         )
 
+    exposed_package_modules = []
+    exposed_package_dbs = []
     for dep_pkgname, dep_modules in package_deps.items():
         exposed_package_dbs.append(libs_by_name[dep_pkgname].package_db)
         for dep_modname in dep_modules:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -344,12 +344,6 @@ def get_packages_info(
         "empty_package_db" if use_empty_lib else "package_db",
     ))
 
-    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
-        ctx,
-        link_style,
-        enable_profiling,
-    )
-
     if haskell_toolchain.packages and resolved != None:
         haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
         pkg_deps = resolved[haskell_toolchain.packages.dynamic]
@@ -371,6 +365,12 @@ def get_packages_info(
     else:
         packagedb_args.add(haskell_toolchain.packages.package_db)
         bin_paths = cmd_args()
+
+    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
+        ctx,
+        link_style,
+        enable_profiling,
+    )
 
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -255,7 +255,7 @@ def target_metadata(
             LinkStyle("shared"),
             specify_pkg_version = False,
             enable_profiling = False,
-            use_empty_lib = False,
+            use_empty_lib = True,
             resolved = resolved,
         )
         package_flag = _package_flag(haskell_toolchain)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -551,7 +551,7 @@ def _compile_module(
         exposed_package_libs = exposed_package_libs,
         exposed_package_args = exposed_package_args,
         exposed_package_dbs = exposed_package_dbs,
-        packagedb_args = packagedb_args,
+        packagedb_args = cmd_args(),
         transitive_deps = libs,
     )
 
@@ -571,9 +571,9 @@ def _compile_module(
         "env",
     ]))
     package_env = cmd_args(delimiter = "\n")
-    packagedb_args = packagedb_tag.tag_artifacts(packages_info.packagedb_args)
+    packagedb_args_tagged = packagedb_tag.tag_artifacts(packagedb_args)
     package_env.add(cmd_args(
-        packagedb_args,
+        packagedb_args_tagged,
         format = "package-db {}",
     ).relative_to(package_env_file, parent = 1))
     ctx.actions.write(
@@ -583,7 +583,7 @@ def _compile_module(
     compile_args_for_file.add(cmd_args(
         packagedb_tag.tag_artifacts(package_env_file),
         prepend = "-package-env",
-        hidden = packagedb_args,
+        hidden = packagedb_args_tagged,
     ))
 
     dep_file = ctx.actions.declare_output(".".join([

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -476,15 +476,6 @@ def _compile_module(
 
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
-    #packages_info = get_packages_info(
-    #    ctx,
-    #    link_style,
-    #    specify_pkg_version = False,
-    #    enable_profiling = enable_profiling,
-    #    use_empty_lib = True,
-    #    resolved = resolved,
-    #    package_deps = package_deps,
-    #)
 
     # Collect library dependencies. Note that these don't need to be in a
     # particular order.
@@ -497,9 +488,6 @@ def _compile_module(
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
     exposed_package_modules = []
-    exposed_package_imports = []
-    exposed_package_objects = []
-    exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
 
     for lib in direct_deps_link_info:
@@ -538,21 +526,6 @@ def _compile_module(
     )
 
     packagedb_args.add(package_db_tset.project_as_args("package_db"))
-
-    # Expose only the packages we depend on directly
-    for lib in haskell_direct_deps_lib_infos:
-        exposed_package_args.add(package_flag, lib.name)
-
-    packages_info = PackagesInfo(
-        exposed_package_modules = [],
-        exposed_package_imports = exposed_package_imports,
-        exposed_package_objects = exposed_package_objects,
-        exposed_package_libs = cmd_args(),
-        exposed_package_args = exposed_package_args,
-        exposed_package_dbs = [],
-        packagedb_args = cmd_args(),
-        transitive_deps = libs,
-    )
 
     # ------------------------------------------------------------
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -119,7 +119,6 @@ CompileResultInfo = record(
 PackagesInfo = record(
     exposed_package_libs = cmd_args,
     exposed_package_args = cmd_args,
-    exposed_package_dbs = field(list[Artifact]),
     packagedb_args = cmd_args,
     transitive_deps = field(HaskellLibraryInfoTSet),
     bin_paths = cmd_args,
@@ -337,7 +336,6 @@ def get_packages_info(
     package_flag = _package_flag(haskell_toolchain)
     exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
-    exposed_package_dbs = []
 
     for lib in libs.traverse():
         exposed_package_libs.hidden(lib.libs)
@@ -385,7 +383,6 @@ def get_packages_info(
     return PackagesInfo(
         exposed_package_libs = exposed_package_libs,
         exposed_package_args = exposed_package_args,
-        exposed_package_dbs = exposed_package_dbs,
         packagedb_args = packagedb_args,
         transitive_deps = libs,
         bin_paths = bin_paths,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -528,25 +528,22 @@ def _compile_module(
         enable_profiling,
     )
 
-    if haskell_toolchain.packages:
-        haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
-        package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
+    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
+    pkg_deps = resolved[haskell_toolchain.packages.dynamic]
+    package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
 
-        toolchain_libs = [
-            dep[HaskellToolchainLibrary].name
-            for dep in ctx.attrs.deps
-            if HaskellToolchainLibrary in dep
-        ] + libs.reduce("packages")
+    toolchain_libs = [
+        dep[HaskellToolchainLibrary].name
+        for dep in ctx.attrs.deps
+        if HaskellToolchainLibrary in dep
+    ] + libs.reduce("packages")
 
-        package_db_tset = ctx.actions.tset(
-            HaskellPackageDbTSet,
-            children = [package_db[name] for name in toolchain_libs if name in package_db]
-        )
+    package_db_tset = ctx.actions.tset(
+        HaskellPackageDbTSet,
+        children = [package_db[name] for name in toolchain_libs if name in package_db]
+    )
 
-        packagedb_args.add(package_db_tset.project_as_args("package_db"))
-    else:
-        packagedb_args.add(haskell_toolchain.packages.package_db)
+    packagedb_args.add(package_db_tset.project_as_args("package_db"))
 
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -485,8 +485,6 @@ def _compile_module(
     #    resolved = resolved,
     #    package_deps = package_deps,
     #)
-    specify_pkg_version = False,
-    use_empty_lib = True,
 
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
@@ -520,7 +518,7 @@ def _compile_module(
                 exposed_package_modules.append(dynamic_info.modules[mod])
 
             if direct.name in package_deps:
-                db = direct.empty_db if use_empty_lib else direct.db
+                db = direct.empty_db if True else direct.db
                 exposed_package_dbs.append(db)
     else:
         for lib in libs.traverse():
@@ -531,7 +529,7 @@ def _compile_module(
             exposed_package_libs.hidden(lib.libs)
 
     packagedb_args = cmd_args(libs.project_as_args(
-        "empty_package_db" if use_empty_lib else "package_db",
+        "empty_package_db" if True else "package_db",
     ))
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
@@ -563,8 +561,6 @@ def _compile_module(
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:
         pkg_name = lib.name
-        if (specify_pkg_version):
-            pkg_name += "-{}".format(lib.version)
 
         exposed_package_args.add(package_flag, pkg_name)
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -117,7 +117,6 @@ CompileResultInfo = record(
 )
 
 PackagesInfo = record(
-    exposed_package_modules = field(None | list[CompiledModuleTSet]),
     exposed_package_imports = field(list[Artifact]),
     exposed_package_objects = field(list[Artifact]),
     exposed_package_libs = cmd_args,
@@ -338,7 +337,6 @@ def get_packages_info(
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
-    exposed_package_modules = None
     exposed_package_imports = []
     exposed_package_objects = []
     exposed_package_libs = cmd_args()
@@ -393,7 +391,6 @@ def get_packages_info(
         exposed_package_args.add(package_flag, pkg_name)
 
     return PackagesInfo(
-        exposed_package_modules = exposed_package_modules,
         exposed_package_imports = exposed_package_imports,
         exposed_package_objects = exposed_package_objects,
         exposed_package_libs = exposed_package_libs,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -544,7 +544,7 @@ def _compile_module(
         exposed_package_args.add(package_flag, lib.name)
 
     packages_info = PackagesInfo(
-        exposed_package_modules = exposed_package_modules,
+        exposed_package_modules = [],
         exposed_package_imports = exposed_package_imports,
         exposed_package_objects = exposed_package_objects,
         exposed_package_libs = cmd_args(),
@@ -654,7 +654,7 @@ def _compile_module(
     # Transitive module dependencies from other packages.
     cross_package_modules = ctx.actions.tset(
         CompiledModuleTSet,
-        children = packages_info.exposed_package_modules,
+        children = exposed_package_modules,
     )
     # Transitive module dependencies from the same package.
     this_package_modules = [

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -340,8 +340,6 @@ def get_packages_info(
     exposed_package_dbs = []
 
     for lib in libs.traverse():
-        # libs of dependencies might be needed at compile time if
-        # we're using Template Haskell:
         exposed_package_libs.hidden(lib.libs)
 
     packagedb_args = cmd_args(libs.project_as_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -482,6 +482,12 @@ def _compile_module(
         children = [package_db[name] for name in toolchain_libs if name in package_db]
     )
 
+    # TODO(ah) breaks recompilation avoidance on transitive toolchain library changes.
+    compile_args_for_file.add(cmd_args(
+        package_db_tset.project_as_args("path"),
+        format="--bin-path={}/bin",
+    ))
+
     packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
     packagedb_args.add(package_db_tset.project_as_args("package_db"))
 
@@ -541,7 +547,6 @@ def _compile_module(
     compile_args_for_file.add("-o", objects[0].as_output())
     compile_args_for_file.add("-ohi", his[0].as_output())
     compile_args_for_file.add("-stubdir", stubs.as_output())
-    compile_args_for_file.add(packages_info.bin_paths)
 
     if link_style in [LinkStyle("static_pic"), LinkStyle("static")]:
         compile_args_for_file.add("-dynamic-too")

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -471,12 +471,6 @@ def _compile_module(
             db = direct.empty_db
             exposed_package_dbs.append(db)
 
-    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
-        ctx,
-        link_style,
-        enable_profiling,
-    )
-
     pkg_deps = resolved[haskell_toolchain.packages.dynamic]
     package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -117,7 +117,6 @@ CompileResultInfo = record(
 )
 
 PackagesInfo = record(
-    exposed_package_imports = field(list[Artifact]),
     exposed_package_objects = field(list[Artifact]),
     exposed_package_libs = cmd_args,
     exposed_package_args = cmd_args,
@@ -337,14 +336,12 @@ def get_packages_info(
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
-    exposed_package_imports = []
     exposed_package_objects = []
     exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
 
     for lib in libs.traverse():
-        exposed_package_imports.extend(lib.import_dirs[enable_profiling])
         exposed_package_objects.extend(lib.objects[enable_profiling])
         # libs of dependencies might be needed at compile time if
         # we're using Template Haskell:
@@ -391,7 +388,6 @@ def get_packages_info(
         exposed_package_args.add(package_flag, pkg_name)
 
     return PackagesInfo(
-        exposed_package_imports = exposed_package_imports,
         exposed_package_objects = exposed_package_objects,
         exposed_package_libs = exposed_package_libs,
         exposed_package_args = exposed_package_args,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -499,7 +499,6 @@ def _compile_module(
     exposed_package_modules = []
     exposed_package_imports = []
     exposed_package_objects = []
-    exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
 
@@ -548,7 +547,7 @@ def _compile_module(
         exposed_package_modules = exposed_package_modules,
         exposed_package_imports = exposed_package_imports,
         exposed_package_objects = exposed_package_objects,
-        exposed_package_libs = exposed_package_libs,
+        exposed_package_libs = cmd_args(),
         exposed_package_args = exposed_package_args,
         exposed_package_dbs = exposed_package_dbs,
         packagedb_args = cmd_args(),
@@ -595,9 +594,6 @@ def _compile_module(
     ])).as_output()
     tagged_dep_file = packagedb_tag.tag_artifacts(dep_file)
     compile_args_for_file.add("--buck2-packagedb-dep", tagged_dep_file)
-
-    if enable_th:
-        compile_args_for_file.add(packages_info.exposed_package_libs)
 
     # Add args from preprocess-able inputs.
     inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -117,7 +117,6 @@ CompileResultInfo = record(
 )
 
 PackagesInfo = record(
-    exposed_package_objects = field(list[Artifact]),
     exposed_package_libs = cmd_args,
     exposed_package_args = cmd_args,
     exposed_package_dbs = field(list[Artifact]),
@@ -336,13 +335,11 @@ def get_packages_info(
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
-    exposed_package_objects = []
     exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
     exposed_package_dbs = []
 
     for lib in libs.traverse():
-        exposed_package_objects.extend(lib.objects[enable_profiling])
         # libs of dependencies might be needed at compile time if
         # we're using Template Haskell:
         exposed_package_libs.hidden(lib.libs)
@@ -388,7 +385,6 @@ def get_packages_info(
         exposed_package_args.add(package_flag, pkg_name)
 
     return PackagesInfo(
-        exposed_package_objects = exposed_package_objects,
         exposed_package_libs = exposed_package_libs,
         exposed_package_args = exposed_package_args,
         exposed_package_dbs = exposed_package_dbs,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -451,6 +451,7 @@ def _compile_module(
         lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
         for lib in direct_deps_link_info
     ])
+    packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
@@ -469,8 +470,6 @@ def _compile_module(
         if direct.name in package_deps:
             db = direct.empty_db
             exposed_package_dbs.append(db)
-
-    packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -439,8 +439,6 @@ def _compile_module(
     osuf, hisuf = output_extensions(link_style, enable_profiling)
     compile_args_for_file.add("-osuf", osuf, "-hisuf", hisuf)
 
-    # ------------------------------------------------------------
-
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
 
@@ -484,8 +482,6 @@ def _compile_module(
 
     packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
     packagedb_args.add(package_db_tset.project_as_args("package_db"))
-
-    # ------------------------------------------------------------
 
     packagedb_tag = ctx.actions.artifact_tag()
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -446,7 +446,6 @@ def _compile_module(
     # particular order.
     direct_deps_link_info = attr_deps_haskell_link_infos(ctx)
 
-    # base is special and gets exposed by default
     exposed_package_modules = []
     exposed_package_dbs = []
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -255,7 +255,7 @@ def target_metadata(
             LinkStyle("shared"),
             specify_pkg_version = False,
             enable_profiling = False,
-            use_empty_lib = True,
+            use_empty_lib = False,
             resolved = resolved,
         )
         package_flag = _package_flag(haskell_toolchain)


### PR DESCRIPTION
Inlines the parts of `get_packages_info` relevant to module compilation and removes them from `get_packages_info`.

The two cases shared relatively little common code and separating them and inlining the module case into `_compile_module` uncovered a few opportunities for deduplication.

- **inline get_packages_info for _compile_module**
- **Inline bool constants**
- **Resolve branches under bool constants**
- **Remove redundant if**
- **Remove duplicate variables**
- **Inline pkg_name**
- **Inline packages_info.packagedb_args**
- **Remove unused exposed_package_libs**
- **inline exposed_package_modules**
- **inline exposed_package_dbs**
- **Remove unused PackagesInfo**
- **get_packages_info remove unused package_deps**
- **get_packages_info consistently use no empty lib**
- **Revert "get_packages_info consistently use no empty lib"**
- **Remove unused exposed_package_modules**
- **Remove unused exposed_package_imports**
- **Remove unused exposed_package_objects**
- **Remove outdated comment**
- **Remove unused exposed_package_dbs**
- **reorder binding**
- **Remove unused binding**
- **Reorder bindings**
- **Remove unused binding**
- **Reorder bindings**
- **Remove inlining markers**
- **Iterate over module's package deps**
- **remove outdated comment**
- **binding order**
