### PR TITLE
Factor out flags shared across modules

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -510,13 +510,6 @@ def _compile_module(
     packagedb_args = cmd_args(libs.project_as_args("empty_package_db"))
     packagedb_args.add(package_db_tset.project_as_args("package_db"))
 
-    exposed_package_modules = []
-    exposed_package_dbs = []
-    for dep_pkgname, dep_modules in package_deps.items():
-        exposed_package_dbs.append(direct_deps_by_name[dep_pkgname].package_db)
-        for dep_modname in dep_modules:
-            exposed_package_modules.append(direct_deps_by_name[dep_pkgname].modules[dep_modname])
-
     packagedb_tag = ctx.actions.artifact_tag()
 
     # TODO[AH] Avoid duplicates and share identical env files.
@@ -594,6 +587,13 @@ def _compile_module(
             delimiter=""
         )
     )
+
+    exposed_package_modules = []
+    exposed_package_dbs = []
+    for dep_pkgname, dep_modules in package_deps.items():
+        exposed_package_dbs.append(direct_deps_by_name[dep_pkgname].package_db)
+        for dep_modname in dep_modules:
+            exposed_package_modules.append(direct_deps_by_name[dep_pkgname].modules[dep_modname])
 
     # Transitive module dependencies from other packages.
     cross_package_modules = ctx.actions.tset(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -437,6 +437,15 @@ def _compile_module(
     osuf, hisuf = output_extensions(link_style, enable_profiling)
     compile_args_for_file.add("-osuf", osuf, "-hisuf", hisuf)
 
+    # Add args from preprocess-able inputs.
+    inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
+    pre = cxx_merge_cpreprocessors(ctx, [], inherited_pre)
+    pre_args = pre.set.project_as_args("args")
+    compile_args_for_file.add(cmd_args(pre_args, format = "-optP={}"))
+
+    if pkgname:
+        compile_args_for_file.add(["-this-unit-id", pkgname])
+
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
 
@@ -527,15 +536,6 @@ def _compile_module(
     ])).as_output()
     tagged_dep_file = packagedb_tag.tag_artifacts(dep_file)
     compile_args_for_file.add("--buck2-packagedb-dep", tagged_dep_file)
-
-    # Add args from preprocess-able inputs.
-    inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
-    pre = cxx_merge_cpreprocessors(ctx, [], inherited_pre)
-    pre_args = pre.set.project_as_args("args")
-    compile_args_for_file.add(cmd_args(pre_args, format = "-optP={}"))
-
-    if pkgname:
-        compile_args_for_file.add(["-this-unit-id", pkgname])
 
     objects = [outputs[obj] for obj in module.objects]
     his = [outputs[hi] for hi in module.interfaces]

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -437,6 +437,13 @@ def _compile_module(
     osuf, hisuf = output_extensions(link_style, enable_profiling)
     compile_args_for_file.add("-osuf", osuf, "-hisuf", hisuf)
 
+    non_haskell_sources = [src for (path, src) in srcs_to_pairs(ctx.attrs.srcs) if not is_haskell_src(path)]
+
+    if non_haskell_sources:
+        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(ctx.label))
+
+        compile_args_for_file.hidden(non_haskell_sources)
+
     # Add args from preprocess-able inputs.
     inherited_pre = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
     pre = cxx_merge_cpreprocessors(ctx, [], inherited_pre)
@@ -556,13 +563,6 @@ def _compile_module(
     aux_deps = ctx.attrs.srcs_deps.get(module.source)
     if aux_deps:
         compile_args_for_file.hidden(aux_deps)
-
-    non_haskell_sources = [src for (path, src) in srcs_to_pairs(ctx.attrs.srcs) if not is_haskell_src(path)]
-
-    if non_haskell_sources:
-        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(ctx.label))
-
-        compile_args_for_file.hidden(non_haskell_sources)
 
     if haskell_toolchain.use_argsfile:
         argsfile = ctx.actions.declare_output(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -527,11 +527,8 @@ def _compile_module(
     package_deps: dict[str, list[str]],
     toolchain_deps: list[str],
     outputs: dict[Artifact, Artifact],
-    resolved: dict[DynamicValue, ResolvedDynamicValue],
     artifact_suffix: str,
-    direct_deps_info: list[HaskellLibraryInfoTSet],
     direct_deps_by_name: dict[str, typing.Any],
-    pkgname: str | None = None,
 ) -> CompiledModuleTSet:
     compile_cmd = cmd_args(common_args.command)
     # These compiler arguments can be passed in a response file.
@@ -729,12 +726,9 @@ def compile(
                 package_deps = package_deps.get(module_name, {}),
                 toolchain_deps = toolchain_deps.get(module_name, []),
                 outputs = outputs,
-                resolved = resolved,
                 md_file=md_file,
                 artifact_suffix = artifact_suffix,
-                direct_deps_info = direct_deps_info,
                 direct_deps_by_name = direct_deps_by_name,
-                pkgname = pkgname,
             )
 
         return [DynamicCompileResultInfo(modules = module_tsets)]

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -396,7 +396,7 @@ def _compile_module(
     enable_haddock: bool,
     enable_th: bool,
     module_name: str,
-    modules: dict[str, _Module],
+    module: _Module,
     module_tsets: dict[str, CompiledModuleTSet],
     md_file: Artifact,
     graph: dict[str, list[str]],
@@ -407,8 +407,6 @@ def _compile_module(
     artifact_suffix: str,
     pkgname: str | None = None,
 ) -> CompiledModuleTSet:
-    module = modules[module_name]
-
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
     compile_cmd = cmd_args(ctx.attrs._ghc_wrapper[RunInfo])
     compile_cmd.add("--ghc", haskell_toolchain.compiler)
@@ -687,7 +685,7 @@ def compile(
                 enable_haddock = enable_haddock,
                 enable_th = module_name in th_modules,
                 module_name = module_name,
-                modules = mapped_modules,
+                module = mapped_modules[module_name],
                 module_tsets = module_tsets,
                 graph = graph,
                 package_deps = package_deps.get(module_name, {}),


### PR DESCRIPTION
Factor out the analysis and generation of arguments that are shared across all modules in a package.

- **Pass only the current module to _compile_module**
- **bubble up non module specific args**
- **bubble cpp flags**
- **bubble up non-module specific extra source files**
- **Factor out common command line arguments**
- **Move common compile flags**
- **Factor out direct_deps_info**
- **Factor out direct_deps_by_name**
- **pull down per module analysis**
- **Factor out packagedb tagging**
- **Factor out common package-db flags**
- **remove unused arguments**
