### PR TITLE
Avoid recompilation with haskell binaries

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -60,13 +60,9 @@ HaskellPackage = record(
 def _haskell_package_info_as_package_db(p: HaskellPackage):
     return cmd_args(p.db)
 
-def _haskell_package_info_as_package_path(p: HaskellPackage):
-    return cmd_args(p.path)
-
 HaskellPackageDbTSet = transitive_set(
     args_projections = {
         "package_db": _haskell_package_info_as_package_db,
-        "path": _haskell_package_info_as_package_path,
     }
 )
 


### PR DESCRIPTION
- **Avoid recompilation for binaries from haskell packages**
- **Remove `path` projection for HaskellPackageDbTSet**
