### PR TITLE
Update to latest GHC -M JSON output

### DIFF
--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -90,19 +90,18 @@ def obtain_target_metadata(args):
     toolchain_packages = load_toolchain_packages(args.toolchain_libs)
     ghc_args = fix_ghc_args(args.ghc_arg, toolchain_packages)
     paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
-    ghc_depends, ghc_options = run_ghc_depends(args.ghc, ghc_args, args.source, paths)
-    th_modules = determine_th_modules(ghc_options, args.source_prefix)
-    package_prefixes = calc_package_prefixes(args.package)
-    module_mapping, module_graph, package_deps, toolchain_deps = interpret_ghc_depends(
-        ghc_depends, args.source_prefix, package_prefixes, toolchain_packages)
+    ghc_depends = run_ghc_depends(args.ghc, ghc_args, args.source, paths)
+    #th_modules = determine_th_modules(ghc_options, args.source_prefix)
+    #package_prefixes = calc_package_prefixes(args.package)
+    #module_mapping, module_graph, package_deps, toolchain_deps = interpret_ghc_depends(
+    #    ghc_depends, args.source_prefix, package_prefixes, toolchain_packages)
     return {
-        "th_modules": th_modules,
-        "module_mapping": module_mapping,
-        "module_graph": module_graph,
-        "package_deps": package_deps,
-        "toolchain_deps": toolchain_deps,
+        #"th_modules": th_modules,
+        #"module_mapping": module_mapping,
+        #"module_graph": module_graph,
+        #"package_deps": package_deps,
+        #"toolchain_deps": toolchain_deps,
         "ghc_depends": ghc_depends,
-        "ghc_options": ghc_options,
     }
 
 
@@ -164,7 +163,6 @@ def fix_ghc_args(ghc_args, toolchain_packages):
 def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
     with tempfile.TemporaryDirectory() as dname:
         json_fname = os.path.join(dname, "depends.json")
-        opt_json_fname = os.path.join(dname, "options.json")
         make_fname = os.path.join(dname, "depends.make")
         args = [
             ghc, "-M", "-include-pkg-deps",
@@ -172,7 +170,6 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             #       backend/src/Foo/Util.<ext> => Foo/Util.<ext>
             "-outputdir", ".",
             "-dep-json", json_fname,
-            "-opt-json", opt_json_fname,
             "-dep-makefile", make_fname,
         ] + ghc_args + sources
 
@@ -182,8 +179,8 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
 
         subprocess.run(args, env=env, check=True)
 
-        with open(json_fname) as f, open(opt_json_fname) as o:
-            return json.load(f), json.load(o)
+        with open(json_fname) as f:
+            return json.load(f)
 
 
 def calc_package_prefixes(package_specs):

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -93,13 +93,15 @@ def obtain_target_metadata(args):
     ghc_depends = run_ghc_depends(args.ghc, ghc_args, args.source, paths)
     th_modules = determine_th_modules(ghc_depends)
     module_mapping = determine_module_mapping(ghc_depends, args.source_prefix)
+    # TODO(ah) handle .hi-boot dependencies
+    module_graph = determine_module_graph(ghc_depends)
     #package_prefixes = calc_package_prefixes(args.package)
     #module_mapping, module_graph, package_deps, toolchain_deps = interpret_ghc_depends(
     #    ghc_depends, args.source_prefix, package_prefixes, toolchain_packages)
     return {
         "th_modules": th_modules,
         "module_mapping": module_mapping,
-        #"module_graph": module_graph,
+        "module_graph": module_graph,
         #"package_deps": package_deps,
         #"toolchain_deps": toolchain_deps,
         "ghc_depends": ghc_depends,
@@ -142,6 +144,13 @@ def determine_module_mapping(ghc_depends, source_prefix):
             result[apparent_name] = modname
 
     return result
+
+
+def determine_module_graph(ghc_depends):
+    return {
+        modname: description.get("modules", [])
+        for modname, description in ghc_depends.items()
+    }
 
 
 def fix_ghc_args(ghc_args, toolchain_packages):

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -91,12 +91,13 @@ def obtain_target_metadata(args):
     ghc_args = fix_ghc_args(args.ghc_arg, toolchain_packages)
     paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
     ghc_depends = run_ghc_depends(args.ghc, ghc_args, args.source, paths)
-    #th_modules = determine_th_modules(ghc_options, args.source_prefix)
+    th_modules = determine_th_modules(ghc_depends)
+    module_mapping = determine_module_mapping(ghc_depends)
     #package_prefixes = calc_package_prefixes(args.package)
     #module_mapping, module_graph, package_deps, toolchain_deps = interpret_ghc_depends(
     #    ghc_depends, args.source_prefix, package_prefixes, toolchain_packages)
     return {
-        #"th_modules": th_modules,
+        "th_modules": th_modules,
         #"module_mapping": module_mapping,
         #"module_graph": module_graph,
         #"package_deps": package_deps,
@@ -110,11 +111,11 @@ def load_toolchain_packages(filepath):
         return json.load(f)
 
 
-def determine_th_modules(ghc_options, source_prefix):
+def determine_th_modules(ghc_depends):
     return [
-        src_to_module_name(strip_prefix_(source_prefix, fname).lstrip("/"))
-        for fname, opts in ghc_options.items()
-        if uses_th(opts)
+        modname
+        for modname, properties in ghc_depends.items()
+        if uses_th(properties.get("options", []))
     ]
 
 
@@ -124,6 +125,9 @@ __TH_EXTENSIONS = ["TemplateHaskell", "TemplateHaskellQuotes", "QuasiQuotes"]
 def uses_th(opts):
     """Determine if a Template Haskell extension is enabled."""
     return any([f"-X{ext}" in opts for ext in __TH_EXTENSIONS])
+
+
+def determine_module_mapping(ghc_depends
 
 
 def fix_ghc_args(ghc_args, toolchain_packages):

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -12,7 +12,7 @@ The result is a JSON object with the following fields:
 * `module_mapping`: Mapping from source inferred module name to actual module name, if different.
 * `module_graph`: Intra-package module dependencies, `dict[modname, list[modname]]`.
 * `package_deps`": Cross-package module dependencies, `dict[modname, dict[pkgname, list[modname]]`.
-* `toolchain_deps`": Toolchain library dependencies, `dict[modname, list[pkgname]]`.
+* `toolchain_deps`": Toolchain library dependencies, `dict[modname, list[pkgid]]`.
 """
 
 import argparse
@@ -166,7 +166,10 @@ def determine_package_deps(ghc_depends, toolchain_packages):
 
             if pkgname in toolchain_by_name:
                 if pkgid == toolchain_by_name[pkgname]:
-                    toolchain_deps.setdefault(modname, []).append(pkgname)
+                    toolchain_deps.setdefault(modname, []).append(pkgid)
+                elif pkgid == "base":
+                    # TODO(ah) why is base's package-id cropped to `base`?
+                    toolchain_deps.setdefault(modname, []).append("base")
                 # TODO(ah) is this an error?
             else:
                 package_deps.setdefault(modname, {})[pkgname] = pkgdep.get("modules", [])

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -102,7 +102,6 @@ def obtain_target_metadata(args):
         "module_graph": module_graph,
         "package_deps": package_deps,
         "toolchain_deps": toolchain_deps,
-        "ghc_depends": ghc_depends,
     }
 
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -101,6 +101,8 @@ def obtain_target_metadata(args):
         "module_graph": module_graph,
         "package_deps": package_deps,
         "toolchain_deps": toolchain_deps,
+        "ghc_depends": ghc_depends,
+        "ghc_options": ghc_options,
     }
 
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -167,9 +167,9 @@ def determine_package_deps(ghc_depends, toolchain_packages):
             if pkgname in toolchain_by_name:
                 if pkgid == toolchain_by_name[pkgname]:
                     toolchain_deps.setdefault(modname, []).append(pkgid)
-                elif pkgid == "base":
+                elif pkgid == pkgname:
                     # TODO(ah) why is base's package-id cropped to `base`?
-                    toolchain_deps.setdefault(modname, []).append("base")
+                    toolchain_deps.setdefault(modname, []).append(toolchain_by_name.get(pkgid, pkgid))
                 # TODO(ah) is this an error?
             else:
                 package_deps.setdefault(modname, {})[pkgname] = pkgdep.get("modules", [])


### PR DESCRIPTION
- **TMP: capture raw GHC -M output**
- **The -opt-json GHC flag was removed**
- **update TH detection**
- **calculate module mapping**
- **determine module graph**
- **determine package and toolchain dependencies**
- **resolve package-ids of package dependencies**
- **obtain base package id from catalog**
- **Remove unused code**
