### PR TITLE
Enable bytecode linking for TH slices

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -592,11 +592,12 @@ def _compile_module(
 
     compile_cmd.hidden(
         abi_tag.tag_artifacts(dependency_modules.project_as_args("interfaces")))
-    if enable_th:
-        compile_cmd.hidden(dependency_modules.project_as_args("objects"))
-        compile_cmd.add(dependency_modules.project_as_args("dyn_objects_dot_o"))
-        compile_cmd.add(cmd_args(dependency_modules.reduce("package_deps").keys(), prepend = "-package"))
-        compile_cmd.add(cmd_args(dependency_modules.reduce("toolchain_deps").keys(), prepend = "-package"))
+    # TODO remove redundant data and dead code
+    #if enable_th:
+    #    compile_cmd.hidden(dependency_modules.project_as_args("objects"))
+    #    compile_cmd.add(dependency_modules.project_as_args("dyn_objects_dot_o"))
+    #    compile_cmd.add(cmd_args(dependency_modules.reduce("package_deps").keys(), prepend = "-package"))
+    #    compile_cmd.add(cmd_args(dependency_modules.reduce("toolchain_deps").keys(), prepend = "-package"))
 
     compile_cmd.add(cmd_args(dependency_modules.reduce("packagedb_deps").keys(), prepend = "--buck2-package-db"))
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -592,6 +592,9 @@ def _compile_module(
 
     compile_cmd.hidden(
         abi_tag.tag_artifacts(dependency_modules.project_as_args("interfaces")))
+    compile_cmd.add("-fbyte-code-and-object-code")
+    if enable_th:
+        compile_cmd.add("-fprefer-byte-code")
     # TODO remove redundant data and dead code
     #if enable_th:
     #    compile_cmd.hidden(dependency_modules.project_as_args("objects"))


### PR DESCRIPTION
Sets `-fprefer-byte-code` for TH splices instead of passing dependency module object files on the command-line.

Assumes [GHC patches][ghc-patches] to enable bytecode linking for one-shot mode for the home module and package dependencies.

[ghc-patches]: https://gitlab.haskell.org/torsten.schmits/ghc/-/commits/tcr/ghc982-2024-07-11-a

- **remove objects from TH compile actions**
- **Set -fprefer-byte-code for TH splices**
- **Remove .dyn_o to .o symlinks**
- **Remove module package dependency tracking**
- **Remove module toolchain lib dependency tracking**
- **Remove module objects reduction**
