### PR TITLE
md.json file should not be a dependency of module compilation 

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -458,7 +458,6 @@ def _compile_module(
     module_name: str,
     module: _Module,
     module_tsets: dict[str, CompiledModuleTSet],
-    md_file: Artifact,
     graph: dict[str, list[str]],
     package_deps: dict[str, list[str]],
     outputs: dict[Artifact, Artifact],
@@ -514,15 +513,6 @@ def _compile_module(
         compile_cmd.hidden(compile_args_for_file)
     else:
         compile_cmd.add(compile_args_for_file)
-
-    compile_cmd.add(
-        cmd_args(
-            cmd_args(md_file, format = "-i{}").parent(),
-            "/",
-            module.prefix_dir,
-            delimiter=""
-        )
-    )
 
     toolchain_deps = []
     library_deps = []
@@ -659,7 +649,6 @@ def compile(
                 graph = graph,
                 package_deps = package_deps.get(module_name, {}),
                 outputs = outputs,
-                md_file=md_file,
                 artifact_suffix = artifact_suffix,
                 direct_deps_by_name = direct_deps_by_name,
                 toolchain_deps_by_name = toolchain_deps_by_name,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -514,6 +514,15 @@ def _compile_module(
     else:
         compile_cmd.add(compile_args_for_file)
 
+    compile_cmd.add(
+        cmd_args(
+            cmd_args(stubs.as_output(), format = "-i{}").parent(),
+            "/",
+            module.prefix_dir,
+            delimiter=""
+        )
+    )
+
     toolchain_deps = []
     library_deps = []
     exposed_package_modules = []


### PR DESCRIPTION
The result of dependency analysis is irrelevant to most of individual module compilation, but it was accidentally added as a dependency, so it triggered unnecessary rebuilds every time import statement changes.
This PR removed that redundancy.