### PR TITLE
Support hs-boot files

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -527,7 +527,7 @@ def _compile_module(
 
     compile_cmd.add(
         cmd_args(
-            cmd_args(md_file, format = "-i{}").parent(),
+            cmd_args(md_file, format = "-i{}", ignore_artifacts=True).parent(),
             "/",
             module.prefix_dir,
             delimiter=""

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -492,7 +492,7 @@ def _compile_module(
     his = [outputs[hi] for hi in module.interfaces]
     stubs = outputs[module.stub_dir]
 
-    compile_args_for_file.add("-outputdir", cmd_args([cmd_args(stubs.as_output()).parent(), module.prefix_dir], delimiter="/"))
+    compile_args_for_file.add("-outputdir", cmd_args([cmd_args(md_file, ignore_artifacts=True).parent(), module.prefix_dir], delimiter="/"))
     compile_args_for_file.add("-o", objects[0].as_output())
     compile_args_for_file.add("-ohi", his[0].as_output())
     compile_args_for_file.add("-stubdir", stubs.as_output())

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -650,8 +650,12 @@ def compile(
         th_modules = md["th_modules"]
         module_map = md["module_mapping"]
         graph = md["module_graph"]
-        boot_deps = md["boot_deps"]
         package_deps = md["package_deps"]
+
+        boot_rev_deps = {}
+        for module_name, boot_deps in md["boot_deps"].items():
+            for boot_dep in boot_deps:
+                boot_rev_deps.setdefault(boot_dep, []).append(module_name)
 
         # TODO GHC --dep-json should integrate boot modules directly into the dependency graph.
         for module_name, module in modules.items():

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -524,15 +524,6 @@ def _compile_module(
     else:
         compile_cmd.add(compile_args_for_file)
 
-    compile_cmd.add(
-        cmd_args(
-            cmd_args(stubs.as_output(), format = "-i{}").parent(),
-            "/",
-            module.prefix_dir,
-            delimiter=""
-        )
-    )
-
     toolchain_deps = []
     library_deps = []
     exposed_package_modules = []

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -380,7 +380,7 @@ def _common_compile_module_args(
     non_haskell_sources = [
         src
         for (path, src) in srcs_to_pairs(ctx.attrs.srcs)
-        if not is_haskell_src(path)
+        if not is_haskell_src(path) and not is_haskell_boot(path)
     ]
 
     if non_haskell_sources:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -644,7 +644,13 @@ def compile(
         th_modules = md["th_modules"]
         module_map = md["module_mapping"]
         graph = md["module_graph"]
+        boot_deps = md["boot_deps"]
         package_deps = md["package_deps"]
+
+        for module_name, boot_deps in md["boot_deps"].items():
+            for boot_dep in boot_deps:
+                graph.setdefault(module_name, []).append(boot_dep + "-boot")
+                graph.setdefault(boot_dep + "-boot", [])
 
         mapped_modules = { module_map.get(k, k): v for k, v in modules.items() }
         module_tsets = {}

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -466,6 +466,7 @@ def _compile_module(
     module_name: str,
     module: _Module,
     module_tsets: dict[str, CompiledModuleTSet],
+    md_file: Artifact,
     graph: dict[str, list[str]],
     package_deps: dict[str, list[str]],
     outputs: dict[Artifact, Artifact],
@@ -523,6 +524,15 @@ def _compile_module(
         compile_cmd.hidden(compile_args_for_file)
     else:
         compile_cmd.add(compile_args_for_file)
+
+    compile_cmd.add(
+        cmd_args(
+            cmd_args(md_file, format = "-i{}").parent(),
+            "/",
+            module.prefix_dir,
+            delimiter=""
+        )
+    )
 
     toolchain_deps = []
     library_deps = []
@@ -690,6 +700,7 @@ def compile(
                 graph = graph,
                 package_deps = package_deps.get(module_name, {}),
                 outputs = outputs,
+                md_file=md_file,
                 artifact_suffix = artifact_suffix,
                 direct_deps_by_name = direct_deps_by_name,
                 toolchain_deps_by_name = toolchain_deps_by_name,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -651,6 +651,8 @@ def compile(
             for boot_dep in boot_deps:
                 graph.setdefault(module_name, []).append(boot_dep + "-boot")
                 graph.setdefault(boot_dep + "-boot", [])
+                if boot_dep + "-boot" not in package_deps:
+                    package_deps[boot_dep + "-boot"] = package_deps[boot_dep]
 
         mapped_modules = { module_map.get(k, k): v for k, v in modules.items() }
         module_tsets = {}

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -653,12 +653,20 @@ def compile(
         boot_deps = md["boot_deps"]
         package_deps = md["package_deps"]
 
+        # TODO GHC --dep-json should integrate boot modules directly into the dependency graph.
+        for module_name, module in modules.items():
+            if not module_name.endswith("-boot"):
+                continue
+
+            # Add boot modules to the module graph
+            graph[module_name] = []
+            # Add package dependencies for the boot module
+            # TODO GHC --dep-json should report boot module dependencies.
+            package_deps[module_name] = package_deps.get(module_name[:-5], [])
+
         for module_name, boot_deps in md["boot_deps"].items():
             for boot_dep in boot_deps:
                 graph.setdefault(module_name, []).append(boot_dep + "-boot")
-                graph.setdefault(boot_dep + "-boot", [])
-                if boot_dep + "-boot" not in package_deps:
-                    package_deps[boot_dep + "-boot"] = package_deps[boot_dep]
 
         mapped_modules = { module_map.get(k, k): v for k, v in modules.items() }
         module_tsets = {}

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -555,8 +555,13 @@ def _build_haskell_lib(
 
     if link_style == LinkStyle("shared"):
         lib = ctx.actions.declare_output(lib_short_path)
+        objects = [
+            object
+            for object in compiled.objects
+            if not object.extension.endswith("-boot")
+        ]
 
-        def do_link(ctx, artifacts, resolved, outputs, lib=lib, objects=compiled.objects):
+        def do_link(ctx, artifacts, resolved, outputs, lib=lib, objects=objects):
             pkg_deps = resolved[haskell_toolchain.packages.dynamic]
             package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
 
@@ -598,7 +603,7 @@ def _build_haskell_lib(
         ctx.actions.dynamic_output(
             dynamic = [],
             promises = [haskell_toolchain.packages.dynamic],
-            inputs = compiled.objects,
+            inputs = objects,
             outputs = [lib.as_output()],
             f = do_link,
         )

--- a/haskell/haskell_haddock.bzl
+++ b/haskell/haskell_haddock.bzl
@@ -124,6 +124,7 @@ def haskell_haddock_lib(ctx: AnalysisContext, pkgname: str, compiled: CompileRes
             html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path).replace(".", "-"))),
         )
         for hi in compiled.hi
+        if not hi.extension.endswith("-boot")
     }
 
     direct_deps_link_info = attr_deps_haskell_link_infos(ctx)

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -45,6 +45,11 @@ HASKELL_EXTENSIONS = [
     ".y",
 ]
 
+HASKELL_BOOT_EXTENSIONS = [
+    ".hs-boot",
+    ".lhs-boot",
+]
+
 # We take a named_set for srcs, which is sometimes a list, sometimes a dict.
 # In future we should only accept a list, but for now, cope with both.
 def srcs_to_pairs(srcs) -> list[(str, Artifact)]:
@@ -56,6 +61,10 @@ def srcs_to_pairs(srcs) -> list[(str, Artifact)]:
 def is_haskell_src(x: str) -> bool:
     _, ext = paths.split_extension(x)
     return ext in HASKELL_EXTENSIONS
+
+def is_haskell_boot(x: str) -> bool:
+    _, ext = paths.split_extension(x)
+    return ext in HASKELL_BOOT_EXTENSIONS
 
 def src_to_module_name(x: str) -> str:
     base, _ext = paths.split_extension(x)


### PR DESCRIPTION
Adds support for Haskell targets that contain module dependency cycles and boot files.

Note, the output of GHC -dep-json could be improved to better support this use-case. The current implementation has to make assumptions about the imports of the `.hs-boot` file.

- **Extract boot module dependencies**
- **Generate module objects for boot files**
- **Extend module dep graph by boot deps**
- **Copy package deps onto boot module**
- **Use md_file for `-outputdir`**
- **Skip stubdir output for boot modules**
- **Skip .o-boot files when linking**
- **Simplify boot module dep graph integration**
- **Calculate reverse boot file dep graph**
- **Add boot module dependencies**
- **Revert "try to fix -i(dir)"**
- **Revert "No more md_json dependency per module"**
- **Set ignore_artifacts on md_file input**
