### PR TITLE
Support source prefix stripping in Buck2

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -17,6 +17,13 @@ def _srcs_arg():
 """),
     }
 
+def _src_strip_prefix_arg():
+    return {
+        "src_strip_prefix": attrs.string(default = "", doc = """
+    A prefix to strip from the source files when compiling.
+"""),
+    }
+
 def _deps_arg():
     return {
         "deps": attrs.list(attrs.dep(), default = [], doc = """
@@ -57,6 +64,7 @@ def _scripts_arg():
 
 haskell_common = struct(
     srcs_arg = _srcs_arg,
+    src_strip_prefix = _src_strip_prefix_arg,
     deps_arg = _deps_arg,
     compiler_flags_arg = _compiler_flags_arg,
     exported_linker_flags_arg = _exported_linker_flags_arg,

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -164,6 +164,7 @@ haskell_library = prelude_rule(
     attrs = (
         # @unsorted-dict-items
         haskell_common.srcs_arg() |
+        haskell_common.src_strip_prefix() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -147,13 +147,20 @@ def _modules_by_name(ctx: AnalysisContext, *, sources: list[Artifact], link_styl
         else:
             stub_dir = None
 
+        prefix_dir = "mod-" + suffix
+
+        src_strip_prefix = getattr(ctx.attrs, "src_strip_prefix", None)
+
+        if src_strip_prefix:
+            prefix_dir += "/" + src_strip_prefix
+
         modules[module_name] = _Module(
             source = src,
             interfaces = interfaces,
             hash = hash,
             objects = objects,
             stub_dir = stub_dir,
-            prefix_dir = "mod-" + suffix)
+            prefix_dir = prefix_dir)
 
     return modules
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -223,7 +223,7 @@ def target_metadata(
 
     ctx.actions.dynamic_output(
         dynamic = [],
-        promises = [haskell_toolchain.packages.dynamic],
+        promises = [haskell_toolchain.packages.dynamic] if haskell_toolchain.packages else [],
         inputs = [],
         outputs = [md_file.as_output()],
         f = get_metadata,
@@ -409,8 +409,12 @@ def _common_compile_module_args(
     ]
     toolchain_libs = direct_toolchain_libs + libs.reduce("packages")
 
-    pkg_deps = resolved[haskell_toolchain.packages.dynamic]
-    package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
+    if haskell_toolchain.packages:
+        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
+        package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
+    else:
+        package_db = []
+
     package_db_tset = ctx.actions.tset(
         HaskellPackageDbTSet,
         children = [package_db[name] for name in toolchain_libs if name in package_db]
@@ -729,7 +733,7 @@ def compile(
                 if enable_profiling else
                 lib.info[link_style]
             ]
-        ] + [ haskell_toolchain.packages.dynamic ],
+        ] + ([ haskell_toolchain.packages.dynamic ] if haskell_toolchain.packages else [ ]),
         inputs = ctx.attrs.srcs,
         outputs = [o.as_output() for o in interfaces + objects + stub_dirs + abi_hashes],
         f = do_compile)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -358,6 +358,9 @@ def _common_compile_module_args(
 
     command.add("-c")
 
+    if getattr(ctx.attrs, "main", None) != None:
+        command.add(["-main-is", ctx.attrs.main])
+
     if enable_haddock:
         command.add("-haddock")
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -86,6 +86,7 @@ CompileResultInfo = record(
     hashes = field(list[Artifact]),
     producing_indices = field(bool),
     module_tsets = field(DynamicValue),
+    src_prefix = field(str),
 )
 
 PackagesInfo = record(
@@ -783,4 +784,5 @@ def compile(
         stubs = stubs_dir,
         producing_indices = False,
         module_tsets = dyn_module_tsets,
+        src_prefix = getattr(ctx.attrs, "src_strip_prefix", ""),
     )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -505,9 +505,17 @@ def _compile_module(
     if module.stub_dir != None:
         stubs = outputs[module.stub_dir]
 
-    compile_args_for_file.add("-outputdir", cmd_args([cmd_args(md_file, ignore_artifacts=True).parent(), module.prefix_dir], delimiter="/"))
     compile_args_for_file.add("-o", objects[0].as_output())
     compile_args_for_file.add("-ohi", his[0].as_output())
+
+    # Set the output directories. We do not use the -outputdir flag, but set the directories individually.
+    # Note, the -outputdir option is shorthand for the combination of -odir, -hidir, -hiedir, -stubdir and -dumpdir.
+    # But setting -hidir effectively disables the use of the search path to look up interface files,
+    # as ghc exclusively looks in that directory when it is set.
+    for dir in ["o", "hie", "dump"]:
+        compile_args_for_file.add(
+           "-{}dir".format(dir), cmd_args([cmd_args(stubs.as_output(), parent=1), module.prefix_dir], delimiter="/"),
+        )
     if module.stub_dir != None:
         compile_args_for_file.add("-stubdir", stubs.as_output())
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1246,8 +1246,11 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     def do_link(ctx, artifacts, resolved, outputs, output=output, objects=objects):
         link_cmd = link.copy() # link is already frozen, make a copy
 
-        pkg_deps = resolved[haskell_toolchain.packages.dynamic]
-        package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
+        if haskell_toolchain.packages:
+            pkg_deps = resolved[haskell_toolchain.packages.dynamic]
+            package_db = pkg_deps[DynamicHaskellPackageDbInfo].packages
+        else:
+            package_db = []
 
         # Add -package-db and -package/-expose-package flags for each Haskell
         # library dependency.
@@ -1280,7 +1283,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
 
     ctx.actions.dynamic_output(
         dynamic = [],
-        promises = [haskell_toolchain.packages.dynamic],
+        promises = [haskell_toolchain.packages.dynamic] if haskell_toolchain.packages else [ ],
         inputs = objects.values(),
         outputs = [output.as_output()],
         f = do_link,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -434,15 +434,15 @@ def _make_package(
     # Don't expose boot sources, as they're only meant to be used for compiling.
     modules = [src_to_module_name(strip_prefix_dir(x, ctx.attrs.src_strip_prefix)) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
 
+    def mk_artifact_dir(dir_prefix: str, profiled: bool, subdir: str = "") -> str:
+        art_suff = get_artifact_suffix(link_style, profiled)
+        return "\"${pkgroot}/" + dir_prefix + "-" + art_suff + subdir + "\""
+
     src_prefix = getattr(ctx.attrs, "src_strip_prefix", "")
     if src_prefix:
         src_prefix = "/" + src_prefix
 
-    def mk_artifact_dir(dir_prefix: str, profiled: bool) -> str:
-        art_suff = get_artifact_suffix(link_style, profiled)
-        return "\"${pkgroot}/" + dir_prefix + "-" + art_suff + src_prefix + "\""
-
-    import_dirs = [mk_artifact_dir("mod", profiled) for profiled in profiling]
+    import_dirs = [mk_artifact_dir("mod", profiled, src_prefix) for profiled in profiling]
 
     conf = [
         "name: " + pkgname,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -423,8 +423,16 @@ def _make_package(
         use_empty_lib: bool) -> Artifact:
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
 
+    def strip_prefix_dir(path, prefix):
+        if not prefix:
+            return path
+        prefix = prefix if prefix.endswith("/") else prefix + "/"
+        if path.startswith(prefix):
+            return path[len(prefix):]
+        return path
+
     # Don't expose boot sources, as they're only meant to be used for compiling.
-    modules = [src_to_module_name(x) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
+    modules = [src_to_module_name(strip_prefix_dir(x, ctx.attrs.src_strip_prefix)) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
 
     def mk_artifact_dir(dir_prefix: str, profiled: bool) -> str:
         art_suff = get_artifact_suffix(link_style, profiled)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -434,9 +434,13 @@ def _make_package(
     # Don't expose boot sources, as they're only meant to be used for compiling.
     modules = [src_to_module_name(strip_prefix_dir(x, ctx.attrs.src_strip_prefix)) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
 
+    src_prefix = getattr(ctx.attrs, "src_strip_prefix", "")
+    if src_prefix:
+        src_prefix = "/" + src_prefix
+
     def mk_artifact_dir(dir_prefix: str, profiled: bool) -> str:
         art_suff = get_artifact_suffix(link_style, profiled)
-        return "\"${pkgroot}/" + dir_prefix + "-" + art_suff + "\""
+        return "\"${pkgroot}/" + dir_prefix + "-" + art_suff + src_prefix + "\""
 
     import_dirs = [mk_artifact_dir("mod", profiled) for profiled in profiling]
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -423,16 +423,8 @@ def _make_package(
         use_empty_lib: bool) -> Artifact:
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
 
-    def strip_prefix_dir(path, prefix):
-        if not prefix:
-            return path
-        prefix = prefix if prefix.endswith("/") else prefix + "/"
-        if path.startswith(prefix):
-            return path[len(prefix):]
-        return path
-
     # Don't expose boot sources, as they're only meant to be used for compiling.
-    modules = [src_to_module_name(strip_prefix_dir(x, ctx.attrs.src_strip_prefix)) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
+    modules = [src_to_module_name(x, ctx.attrs.src_strip_prefix) for x, _ in srcs_to_pairs(ctx.attrs.srcs) if is_haskell_src(x)]
 
     def mk_artifact_dir(dir_prefix: str, profiled: bool, subdir: str = "") -> str:
         art_suff = get_artifact_suffix(link_style, profiled)

--- a/haskell/haskell_haddock.bzl
+++ b/haskell/haskell_haddock.bzl
@@ -118,10 +118,10 @@ def haskell_haddock_lib(ctx: AnalysisContext, pkgname: str, compiled: CompileRes
         cmd.add("--source-entity", source_entity)
 
     haddock_infos = {
-        src_to_module_name(hi.short_path): _HaddockInfo(
+        src_to_module_name(hi.short_path, compiled.src_prefix): _HaddockInfo(
             interface = hi,
-            haddock = ctx.actions.declare_output("haddock-interface/{}.haddock".format(src_to_module_name(hi.short_path))),
-            html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path).replace(".", "-"))),
+            haddock = ctx.actions.declare_output("haddock-interface/{}.haddock".format(src_to_module_name(hi.short_path, compiled.src_prefix))),
+            html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path, compiled.src_prefix).replace(".", "-"))),
         )
         for hi in compiled.hi
         if not hi.extension.endswith("-boot")

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -35,6 +35,7 @@ load(
 )
 load("@prelude//utils:platform_flavors_util.bzl", "by_platform")
 load("@prelude//utils:utils.bzl", "flatten")
+load("@prelude//utils:strings.bzl", "strip_prefix")
 
 HASKELL_EXTENSIONS = [
     ".hs",
@@ -66,8 +67,13 @@ def is_haskell_boot(x: str) -> bool:
     _, ext = paths.split_extension(x)
     return ext in HASKELL_BOOT_EXTENSIONS
 
-def src_to_module_name(x: str) -> str:
+def src_to_module_name(x: str, src_prefix: str = "") -> str:
     base, _ext = paths.split_extension(x)
+    if src_prefix:
+        prefix = src_prefix if src_prefix.endswith("/") else src_prefix + "/"
+        stripped = strip_prefix(prefix, base)
+        if stripped: base = stripped
+
     return base.replace("/", ".")
 
 def _by_platform(ctx: AnalysisContext, xs: list[(str, list[typing.Any])]) -> list[typing.Any]:


### PR DESCRIPTION
This PR introduces a `src_strip_prefix` attribute for haskell_library rules. AFAICS, source prefix stripping is not needed for haskell_binary rules, since that attribute is only relevant for package conf files and for locating interface files.

**Note**

We also could infer the source prefix from the md.json file automatically.

But the information is needed at three places currently: 

1) when compiling a module
2) when writing the package conf file(s)
3) when generating haddock docs

The first has access to the md.json file since its actions are run inside a dynamic output action, but the latter ones do not. 

Using the information from the md.json file, it also would be possible to support source files in several sub-directories -- not sure how commonly this is seen in the wild (for cabal projects).