### PR TITLE
Support boot files with imports

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -653,37 +653,6 @@ def compile(
         graph = md["module_graph"]
         package_deps = md["package_deps"]
 
-        boot_rev_deps = {}
-        for module_name, boot_deps in md["boot_deps"].items():
-            for boot_dep in boot_deps:
-                boot_rev_deps.setdefault(boot_dep + "-boot", []).append(module_name)
-
-        # TODO GHC --dep-json should integrate boot modules directly into the dependency graph.
-        for module_name, module in modules.items():
-            if not module_name.endswith("-boot"):
-                continue
-
-            # Add boot modules to the module graph
-            graph[module_name] = []
-            # TODO GHC --dep-json should report boot module dependencies.
-            # The following is a naive approximation of the boot module's dependencies,
-            # taking the corresponding module's dependencies
-            # minus those that depend on the boot module.
-
-            # Add module dependencies for the boot module
-            graph[module_name].extend([
-                dep
-                for dep in graph[module_name[:-5]]
-                if not dep in boot_rev_deps[module_name]
-            ])
-
-            # Add package dependencies for the boot module
-            package_deps[module_name] = package_deps.get(module_name[:-5], [])
-
-        for module_name, boot_deps in md["boot_deps"].items():
-            for boot_dep in boot_deps:
-                graph.setdefault(module_name, []).append(boot_dep + "-boot")
-
         mapped_modules = { module_map.get(k, k): v for k, v in modules.items() }
         module_tsets = {}
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -163,6 +163,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
     with tempfile.TemporaryDirectory() as dname:
         json_fname = os.path.join(dname, "depends.json")
         make_fname = os.path.join(dname, "depends.make")
+        haskell_sources = list(filter(is_haskell_src, sources))
         args = [
             ghc, "-M", "-include-pkg-deps",
             # Note: `-outputdir '.'` removes the prefix of all targets:
@@ -170,7 +171,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             "-outputdir", ".",
             "-dep-json", json_fname,
             "-dep-makefile", make_fname,
-        ] + ghc_args + sources
+        ] + ghc_args + haskell_sources
 
         env = os.environ.copy()
         path = env.get("PATH", "")

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -7,7 +7,7 @@
 * The cross-package module dependencies.
 * Which modules require Template Haskell.
 
-Note, boot files will be represented by the module name with a `-boot` suffix.
+Note, boot files will be represented by a `-boot` suffix in the module name.
 
 The result is a JSON object with the following fields:
 * `th_modules`: List of modules that require Template Haskell.

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -174,6 +174,12 @@ def determine_package_deps(ghc_depends):
             pkgname = pkgdep.get("name")
             package_deps.setdefault(modname, {})[pkgname] = pkgdep.get("modules", [])
 
+        boot_description = description.get("boot", None)
+        if boot_description != None:
+            for pkgdep in boot_description.get("packages", {}):
+                pkgname = pkgdep.get("name")
+                package_deps.setdefault(modname + "-boot", {})[pkgname] = pkgdep.get("modules", [])
+
     return package_deps
 
 


### PR DESCRIPTION
- **Filter boot files from GHC -M command line**
- **Handle boot files in module_mapping**
- **Handle boot files in module graph**
- **Handle boot files in package deps**
- **Support imports in boot files**
- **wording**

Adds support for Haskell boot files that themselves import other Haskell modules or other Haskell boot modules.

Depends on https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11994/diffs?commit_id=ecf726ab5a75fdc0a92c0849cce82ed227240360
