### PR TITLE
Redirect GHC stdout to stderr

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -522,7 +522,7 @@ def _compile_module(
     # as ghc exclusively looks in that directory when it is set.
     for dir in ["o", "hie", "dump"]:
         compile_args_for_file.add(
-           "-{}dir".format(dir), cmd_args([cmd_args(stubs.as_output(), parent=1), module.prefix_dir], delimiter="/"),
+           "-{}dir".format(dir), cmd_args([cmd_args(md_file, ignore_artifacts=True, parent=1), module.prefix_dir], delimiter="/"),
         )
     if module.stub_dir != None:
         compile_args_for_file.add("-stubdir", stubs.as_output())

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -184,7 +184,9 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             print(shlex.join(args), file=sys.stderr)
 
         # Always forward stdout/stderr.
-        sys.stdout.buffer.write(res.stdout)
+        # Note, Buck2 swallows stdout on successful builds.
+        # Redirect to stderr to avoid this.
+        sys.stderr.buffer.write(res.stdout)
         sys.stderr.buffer.write(res.stderr)
 
         if res.returncode != 0:

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -12,6 +12,7 @@ import argparse
 import os
 from pathlib import Path
 import subprocess
+import sys
 
 
 def main():
@@ -61,7 +62,9 @@ def main():
     path = env.get("PATH", "")
     env["PATH"] = os.pathsep.join([path] + aux_paths)
 
-    returncode = subprocess.call(cmd, env=env)
+    # Note, Buck2 swallows stdout on successful builds.
+    # Redirect to stderr to avoid this.
+    returncode = subprocess.call(cmd, env=env, stdout=sys.stderr.buffer)
     if returncode != 0:
         return returncode
 


### PR DESCRIPTION
This is to work around Buck2 swallowing stdout on successful builds, as discussed in https://github.com/MercuryTechnologies/buck2-prelude/pull/2#issuecomment-2292992546.

- **Improve error messages for GHC compilation failures**
- **Improve error messages for metadata generation**
- **Redirect GHC stdout to stderr**
