### PR TITLE
Infer source prefix automatically

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -17,13 +17,6 @@ def _srcs_arg():
 """),
     }
 
-def _src_strip_prefix_arg():
-    return {
-        "src_strip_prefix": attrs.string(default = "", doc = """
-    A prefix to strip from the source files when compiling.
-"""),
-    }
-
 def _deps_arg():
     return {
         "deps": attrs.list(attrs.dep(), default = [], doc = """
@@ -71,7 +64,6 @@ def _external_tools_arg():
 
 haskell_common = struct(
     srcs_arg = _srcs_arg,
-    src_strip_prefix = _src_strip_prefix_arg,
     deps_arg = _deps_arg,
     compiler_flags_arg = _compiler_flags_arg,
     exported_linker_flags_arg = _exported_linker_flags_arg,

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -165,7 +165,6 @@ haskell_library = prelude_rule(
     attrs = (
         # @unsorted-dict-items
         haskell_common.srcs_arg() |
-        haskell_common.src_strip_prefix() |
         haskell_common.external_tools_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -520,8 +520,6 @@ def _compile_module(
 
     objects = [outputs[obj] for obj in module.objects]
     his = [outputs[hi] for hi in module.interfaces]
-    if module.stub_dir != None:
-        stubs = outputs[module.stub_dir]
 
     compile_args_for_file.add("-o", objects[0].as_output())
     compile_args_for_file.add("-ohi", his[0].as_output())
@@ -535,6 +533,7 @@ def _compile_module(
            "-{}dir".format(dir), cmd_args([cmd_args(md_file, ignore_artifacts=True, parent=1), module.prefix_dir], delimiter="/"),
         )
     if module.stub_dir != None:
+        stubs = outputs[module.stub_dir]
         compile_args_for_file.add("-stubdir", stubs.as_output())
 
     if link_style in [LinkStyle("static_pic"), LinkStyle("static")]:

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -96,7 +96,6 @@ CompileResultInfo = record(
     hashes = field(list[Artifact]),
     producing_indices = field(bool),
     module_tsets = field(DynamicValue),
-    src_prefix = field(str),
 )
 
 PackagesInfo = record(
@@ -783,5 +782,4 @@ def compile(
         stubs = stubs_dir,
         producing_indices = False,
         module_tsets = dyn_module_tsets,
-        src_prefix = getattr(ctx.attrs, "src_strip_prefix", ""),
     )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -42,6 +42,7 @@ load(
 load("@prelude//:paths.bzl", "paths")
 load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
 load("@prelude//utils:strings.bzl", "strip_prefix")
+load("@prelude//haskell:util.bzl", "source_prefix")
 
 CompiledModuleInfo = provider(fields = {
     "abi": provider_field(Artifact),
@@ -631,18 +632,7 @@ def _compile_module(
         }
     )
 
-    source_path = paths.replace_extension(module.source.short_path, "")
-    module_name_for_file = src_to_module_name(source_path)
-
-    # assert that source_path (without extension) and its module name have the same length
-    if len(source_path) != len(module_name_for_file):
-        fail("{} should have the same length as {}".format(source_path, module_name_for_file))
-
-    if module_name != module_name_for_file and module_name_for_file.endswith("." + module_name):
-        # N.B. the prefix could have some '.' characters in it, use the source_path to determine the prefix
-        src_prefix = source_path[0:-len(module_name) - 1]
-    else:
-        src_prefix = ""
+    src_prefix = source_prefix(module.source, module_name)
 
     module_tset = ctx.actions.tset(
         CompiledModuleTSet,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -705,6 +705,48 @@ def compile(
         graph = md["module_graph"]
         package_deps = md["package_deps"]
 
+        # boot_rev_deps = {}
+        # for module_name, boot_deps in md["boot_deps"].items():
+        #     for boot_dep in boot_deps:
+        #         boot_rev_deps.setdefault(boot_dep + "-boot", []).append(module_name)
+
+        # # TODO GHC --dep-json should integrate boot modules directly into the dependency graph.
+        # for module_name, module in modules.items():
+        #     if not module_name.endswith("-boot"):
+        #         continue
+
+        #     # deduce the real name from the corresponding non-boot module
+        #     non_boot_module_name = module_name[:-5]
+        #     non_boot_module_name = module_map.get(non_boot_module_name, non_boot_module_name)
+
+        #     boot_module_name = non_boot_module_name + "-boot"
+
+        #     if module_name != boot_module_name:
+        #         module_map[module_name] = boot_module_name
+
+        #     # Add boot modules to the module graph
+        #     graph[boot_module_name] = []
+        #     # TODO GHC --dep-json should report boot module dependencies.
+        #     # The following is a naive approximation of the boot module's dependencies,
+        #     # taking the corresponding module's dependencies
+        #     # minus those that depend on the boot module.
+
+        #     # Add module dependencies for the boot module
+        #     graph[boot_module_name].extend([
+        #         dep
+        #         for dep in graph[non_boot_module_name]
+        #         if not dep in boot_rev_deps[boot_module_name]
+        #     ])
+
+        #     # Add package dependencies for the boot module
+        #     package_deps[boot_module_name] = package_deps.get(non_boot_module_name, [])
+
+        # for module_name, boot_deps in md["boot_deps"].items():
+        #     for boot_dep in boot_deps:
+        #         graph.setdefault(module_name, []).append(boot_dep + "-boot")
+
+        #>>>>>>> 8a06e69b (Handle source prefix for boot modules)
+
         mapped_modules = { module_map.get(k, k): v for k, v in modules.items() }
         module_tsets = {}
 

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -89,11 +89,9 @@ load(
     "attr_deps_profiling_link_infos",
     "attr_deps_shared_library_infos",
     "get_artifact_suffix",
-    "is_haskell_src",
     "output_extensions",
     "src_to_module_name",
-    "srcs_to_pairs",
-    "source_prefix",
+    "get_source_prefixes",
 )
 load(
     "@prelude//linking:link_groups.bzl",
@@ -442,21 +440,9 @@ def _make_package(
         md = artifacts[md_file].read_json()
         module_map = md["module_mapping"]
 
-        modules = []
-        source_prefixes = {}
-        for path, src in srcs_to_pairs(ctx.attrs.srcs):
-            # Don't expose boot sources, as they're only meant to be used for compiling.
-            if not is_haskell_src(path):
-                continue
+        source_prefixes = get_source_prefixes(ctx.attrs.srcs, module_map)
 
-            name = src_to_module_name(path)
-            prefix = source_prefix(src, module_map.get(name, name))
-            source_prefixes[prefix] = None
-
-            modules.append(src_to_module_name(path[len(prefix) + 1:]))
-
-        source_prefixes = source_prefixes.keys()
-
+        modules = md["module_graph"].keys()
         import_dirs = [mk_artifact_dir("mod", profiled, src_prefix) for profiled in profiling for src_prefix in source_prefixes]
 
         conf = [

--- a/haskell/haskell_haddock.bzl
+++ b/haskell/haskell_haddock.bzl
@@ -118,10 +118,10 @@ def haskell_haddock_lib(ctx: AnalysisContext, pkgname: str, compiled: CompileRes
         cmd.add("--source-entity", source_entity)
 
     haddock_infos = {
-        src_to_module_name(hi.short_path, compiled.src_prefix): _HaddockInfo(
+        src_to_module_name(hi.short_path): _HaddockInfo(
             interface = hi,
-            haddock = ctx.actions.declare_output("haddock-interface/{}.haddock".format(src_to_module_name(hi.short_path, compiled.src_prefix))),
-            html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path, compiled.src_prefix).replace(".", "-"))),
+            haddock = ctx.actions.declare_output("haddock-interface/{}.haddock".format(src_to_module_name(hi.short_path))),
+            html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path).replace(".", "-"))),
         )
         for hi in compiled.hi
         if not hi.extension.endswith("-boot")

--- a/haskell/haskell_haddock.bzl
+++ b/haskell/haskell_haddock.bzl
@@ -16,6 +16,7 @@ load(
     "attr_deps",
     "attr_deps_haskell_link_infos",
     "src_to_module_name",
+    "source_prefix",
 )
 load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
 
@@ -65,13 +66,13 @@ def _haddock_dump_interface(
         for dep_name in graph[module_name]
     ]
 
-    interface_path = haddock_info.interface.short_path
+    prefix = source_prefix(haddock_info.interface, module_name)
 
-    module_name_for_file = src_to_module_name(interface_path)
-
-    if module_name != module_name_for_file and module_name_for_file.endswith("." + module_name):
-        start = len(module_name_for_file) - len(module_name)
-        html_output = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(interface_path[start:]).replace(".", "-")))
+    if prefix:
+        interface_path = haddock_info.interface.short_path
+        html_output = ctx.actions.declare_output(
+            "haddock-html/{}.html".format(src_to_module_name(interface_path[len(prefix) + 1:]).replace(".", "-"))
+        )
         make_copy = True
     else:
         html_output = outputs[haddock_info.html]

--- a/haskell/haskell_haddock.bzl
+++ b/haskell/haskell_haddock.bzl
@@ -16,9 +16,9 @@ load(
     "attr_deps",
     "attr_deps_haskell_link_infos",
     "src_to_module_name",
-    "source_prefix",
 )
 load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
+load("@prelude//:paths.bzl", "paths")
 
 HaskellHaddockInfo = provider(
     fields = {
@@ -43,6 +43,9 @@ _HaddockInfoTSet = transitive_set(
     }
 )
 
+def _haddock_module_to_html(module_name: str) -> str:
+    return module_name.replace(".", "-") + ".html"
+
 def _haddock_dump_interface(
     ctx: AnalysisContext,
     cmd: cmd_args,
@@ -66,16 +69,14 @@ def _haddock_dump_interface(
         for dep_name in graph[module_name]
     ]
 
-    prefix = source_prefix(haddock_info.interface, module_name)
+    expected_html = outputs[haddock_info.html]
+    module_html = _haddock_module_to_html(module_name)
 
-    if prefix:
-        interface_path = haddock_info.interface.short_path
-        html_output = ctx.actions.declare_output(
-            "haddock-html/{}.html".format(src_to_module_name(interface_path[len(prefix) + 1:]).replace(".", "-"))
-        )
+    if paths.basename(expected_html.short_path) != module_html:
+        html_output = ctx.actions.declare_output("haddock-html", module_html)
         make_copy = True
     else:
-        html_output = outputs[haddock_info.html]
+        html_output = expected_html 
         make_copy = False
 
     ctx.actions.run(
@@ -99,7 +100,9 @@ def _haddock_dump_interface(
         no_outputs_cleanup = True,
     )
     if make_copy:
-        ctx.actions.copy_file(outputs[haddock_info.html].as_output(), html_output)
+        # XXX might as well use `symlink_file`` but that does not work with buck2 RE
+        # (see https://github.com/facebook/buck2/issues/222)
+        ctx.actions.copy_file(expected_html.as_output(), html_output)
 
     return ctx.actions.tset(
         _HaddockInfoTSet,
@@ -136,7 +139,7 @@ def haskell_haddock_lib(ctx: AnalysisContext, pkgname: str, compiled: CompileRes
         src_to_module_name(hi.short_path): _HaddockInfo(
             interface = hi,
             haddock = ctx.actions.declare_output("haddock-interface/{}.haddock".format(src_to_module_name(hi.short_path))),
-            html = ctx.actions.declare_output("haddock-html/{}.html".format(src_to_module_name(hi.short_path).replace(".", "-"))),
+            html = ctx.actions.declare_output("haddock-html", _haddock_module_to_html(src_to_module_name(hi.short_path))),
         )
         for hi in compiled.hi
         if not hi.extension.endswith("-boot")

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -171,3 +171,20 @@ def get_artifact_suffix(link_style: LinkStyle, enable_profiling: bool, suffix: s
     if enable_profiling:
         artifact_suffix += "-prof"
     return artifact_suffix + suffix
+
+def source_prefix(source: Artifact, module_name: str) -> str:
+    """Determine the directory prefix of the given artifact, considering that ghc has determined `module_name` for that file."""
+    source_path = paths.replace_extension(source.short_path, "")
+
+    module_name_for_file = src_to_module_name(source_path)
+
+    # assert that source_path (without extension) and its module name have the same length
+    if len(source_path) != len(module_name_for_file):
+        fail("{} should have the same length as {}".format(source_path, module_name_for_file))
+
+    if module_name != module_name_for_file and module_name_for_file.endswith("." + module_name):
+        # N.B. the prefix could have some '.' characters in it, use the source_path to determine the prefix
+        return source_path[0:-len(module_name) - 1]
+
+    return ""
+

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -172,7 +172,7 @@ def get_artifact_suffix(link_style: LinkStyle, enable_profiling: bool, suffix: s
         artifact_suffix += "-prof"
     return artifact_suffix + suffix
 
-def source_prefix(source: Artifact, module_name: str) -> str:
+def _source_prefix(source: Artifact, module_name: str) -> str:
     """Determine the directory prefix of the given artifact, considering that ghc has determined `module_name` for that file."""
     source_path = paths.replace_extension(source.short_path, "")
 
@@ -188,3 +188,17 @@ def source_prefix(source: Artifact, module_name: str) -> str:
 
     return ""
 
+
+def get_source_prefixes(srcs: list[Artifact], module_map: dict[str, str]) -> list[str]:
+    """Determine source prefixes for the given haskell files and a mapping from source file module name to module name."""
+    source_prefixes = {}
+    for path, src in srcs_to_pairs(srcs):
+        if not is_haskell_src(path):
+            continue
+
+        name = src_to_module_name(path)
+        real_name = module_map.get(name)
+        prefix = _source_prefix(src, real_name) if real_name else ""
+        source_prefixes[prefix] = None
+
+    return source_prefixes.keys()

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -35,7 +35,6 @@ load(
 )
 load("@prelude//utils:platform_flavors_util.bzl", "by_platform")
 load("@prelude//utils:utils.bzl", "flatten")
-load("@prelude//utils:strings.bzl", "strip_prefix")
 
 HASKELL_EXTENSIONS = [
     ".hs",
@@ -67,13 +66,8 @@ def is_haskell_boot(x: str) -> bool:
     _, ext = paths.split_extension(x)
     return ext in HASKELL_BOOT_EXTENSIONS
 
-def src_to_module_name(x: str, src_prefix: str = "") -> str:
+def src_to_module_name(x: str) -> str:
     base, _ext = paths.split_extension(x)
-    if src_prefix:
-        prefix = src_prefix if src_prefix.endswith("/") else src_prefix + "/"
-        stripped = strip_prefix(prefix, base)
-        if stripped: base = stripped
-
     return base.replace("/", ".")
 
 def _by_platform(ctx: AnalysisContext, xs: list[(str, list[typing.Any])]) -> list[typing.Any]:


### PR DESCRIPTION
- **Determine source prefix automatically**
- **Use inferred source_prefixes in _compile_module**
- **Move package conf actions into dynamic ouput**
- **Infer source prefixes for exposed-modules and import-dirs**
- **Properly handle html output with source prefixes**
- **Fix handling of output directories**
- **Handle source prefix for boot modules**
- ... revert changes using the `src_strip_prefix` attribute
