### PR TITLE
Add srcs_envs. configure environment variable per source.

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -69,6 +69,13 @@ def _external_tools_arg():
 """),
     }
 
+def _srcs_envs_arg():
+    return {
+        "srcs_envs": attrs.dict(attrs.source(), attrs.list(attrs.tuple(attrs.string(), attrs.arg())), default = {}, doc = """
+    Individual run-time env for each source compilation.
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     src_strip_prefix = _src_strip_prefix_arg,
@@ -77,4 +84,5 @@ haskell_common = struct(
     exported_linker_flags_arg = _exported_linker_flags_arg,
     scripts_arg = _scripts_arg,
     external_tools_arg = _external_tools_arg,
+    srcs_envs_arg = _srcs_envs_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -166,6 +166,7 @@ haskell_library = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.src_strip_prefix() |
         haskell_common.external_tools_arg() |
+        haskell_common.srcs_envs_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -546,7 +546,6 @@ def _compile_module(
 
     src_envs = ctx.attrs.srcs_envs.get(module.source)
     if src_envs:
-        #env_strs = ["{}={}".format(k, v) for k, v in src_envs]
         for k, v in src_envs:
             compile_args_for_file.add(cmd_args(
                 k,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -544,6 +544,20 @@ def _compile_module(
     if aux_deps:
         compile_args_for_file.hidden(aux_deps)
 
+    src_envs = ctx.attrs.srcs_envs.get(module.source)
+    if src_envs:
+        #env_strs = ["{}={}".format(k, v) for k, v in src_envs]
+        for k, v in src_envs:
+            compile_args_for_file.add(cmd_args(
+                k,
+                format="--extra-env-key={}",
+            ))
+            compile_args_for_file.add(cmd_args(
+                v,
+                format="--extra-env-value={}",
+            ))
+
+
     if haskell_toolchain.use_argsfile:
         argsfile = ctx.actions.declare_output(
             "haskell_compile_" + artifact_suffix + ".argsfile",

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -85,6 +85,7 @@ def main():
 
     extra_env_keys = [str(k) for k in args.extra_env_key]
     extra_env_values = [str(v) for v in args.extra_env_value]
+    assert len(extra_env_keys) == len(extra_env_values), "number of --extra-env-key and --extra-env-value flags must match"
     n_extra_env = len(extra_env_keys)
     if n_extra_env > 0:
         for i in range(0, n_extra_env):

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -52,13 +52,26 @@ def main():
         default=[],
         help="Add given path to PATH.",
     )
-
     parser.add_argument(
         "--bin-exe",
         type=Path,
         action="append",
         default=[],
         help="Add given exe (more specific than bin-path)",
+    )
+    parser.add_argument(
+        "--extra-env-key",
+        type=str,
+        action="append",
+        default=[],
+        help="Extra environment variable name",
+    )
+    parser.add_argument(
+        "--extra-env-value",
+        type=str,
+        action="append",
+        default=[],
+        help="Extra environment variable value",
     )
 
     args, ghc_args = parser.parse_known_args()
@@ -69,6 +82,15 @@ def main():
     env = os.environ.copy()
     path = env.get("PATH", "")
     env["PATH"] = os.pathsep.join([path] + aux_paths)
+
+    extra_env_keys = [str(k) for k in args.extra_env_key]
+    extra_env_values = [str(v) for v in args.extra_env_value]
+    n_extra_env = len(extra_env_keys)
+    if n_extra_env > 0:
+        for i in range(0, n_extra_env):
+            k = extra_env_keys[i]
+            v = extra_env_values[i]
+            env[k] = v
 
     # Note, Buck2 swallows stdout on successful builds.
     # Redirect to stderr to avoid this.


### PR DESCRIPTION
For some cases where TH needs environment variable, the `srcs_envs` field is added, and user can set an env variable for a specific module. 
ghc_wrapper takes `--extra-env-key` and `--extra-env-value` to set up for GHC.
Note that the value is `attrs.arg()` type so that Buck2 macro like `$(location //:target)` can be used.  