### PR TITLE
Fix: Missing instance of external_tools_arg

### DIFF
--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -46,6 +46,7 @@ haskell_binary = prelude_rule(
         native_common.link_group_public_deps_label() |
         native_common.link_style() |
         haskell_common.srcs_arg() |
+        haskell_common.external_tools_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |


### PR DESCRIPTION
See https://github.com/MercuryTechnologies/buck2-prelude/pull/27
