### PR TITLE
Support multiple source directories

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -195,6 +195,7 @@ def target_metadata(
             specify_pkg_version = False,
             enable_profiling = False,
             use_empty_lib = True,
+            for_deps = True,
             resolved = resolved,
         )
         package_flag = _package_flag(haskell_toolchain)
@@ -263,6 +264,7 @@ def get_packages_info(
         specify_pkg_version: bool,
         enable_profiling: bool,
         use_empty_lib: bool,
+        for_deps: bool = False,
         resolved: None | dict[DynamicValue, ResolvedDynamicValue] = None) -> PackagesInfo:
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
@@ -282,9 +284,14 @@ def get_packages_info(
     for lib in libs.traverse():
         exposed_package_libs.hidden(lib.libs)
 
-    packagedb_args = cmd_args(libs.project_as_args(
-        "empty_package_db" if use_empty_lib else "package_db",
-    ))
+    if for_deps:
+        package_db_projection = "deps_package_db"
+    elif use_empty_lib:
+        package_db_projection = "empty_package_db"
+    else:
+        package_db_projection = "package_db"
+
+    packagedb_args = cmd_args(libs.project_as_args(package_db_projection))
 
     if haskell_toolchain.packages and resolved != None:
         haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -420,7 +420,8 @@ def _make_package(
         profiling: list[bool],
         enable_profiling: bool,
         use_empty_lib: bool,
-        md_file: Artifact) -> Artifact:
+        md_file: Artifact,
+        for_deps: bool = False) -> Artifact:
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
 
     def mk_artifact_dir(dir_prefix: str, profiled: bool, subdir: str = "") -> str:
@@ -429,7 +430,10 @@ def _make_package(
             suffix = paths.join(suffix, subdir)
         return "\"${pkgroot}/" + dir_prefix + "-" + suffix + "\""
 
-    if use_empty_lib:
+    if for_deps:
+        pkg_conf = ctx.actions.declare_output("pkg-" + artifact_suffix + "_deps.conf")
+        db = ctx.actions.declare_output("db-" + artifact_suffix + "_deps", dir = True)
+    elif use_empty_lib:
         pkg_conf = ctx.actions.declare_output("pkg-" + artifact_suffix + "_empty.conf")
         db = ctx.actions.declare_output("db-" + artifact_suffix + "_empty", dir = True)
     else:
@@ -443,7 +447,13 @@ def _make_package(
         source_prefixes = get_source_prefixes(ctx.attrs.srcs, module_map)
 
         modules = md["module_graph"].keys()
-        import_dirs = [mk_artifact_dir("mod", profiled, src_prefix) for profiled in profiling for src_prefix in source_prefixes]
+
+        # XXX use a single import dir when this package db is used for resolving dependencies with ghc -M,
+        #     which works around an issue with multiple import dirs resulting in GHC trying to locate interface files
+        #     for each exposed module
+        import_dirs = ["."] if for_deps else [
+            mk_artifact_dir("mod", profiled, src_prefix) for profiled in profiling for src_prefix in source_prefixes
+        ]
 
         conf = [
             "name: " + pkgname,
@@ -702,11 +712,25 @@ def _build_haskell_lib(
         use_empty_lib = True,
         md_file = md_file,
     )
+    deps_db = _make_package(
+        ctx,
+        link_style,
+        pkgname,
+        None,
+        uniq_infos,
+        import_artifacts.keys(),
+        enable_profiling = enable_profiling,
+        use_empty_lib = True,
+        md_file = md_file,
+        for_deps = True,
+    )
+
 
     hlib = HaskellLibraryInfo(
         name = pkgname,
         db = db,
         empty_db = empty_db,
+        deps_db = deps_db,
         id = pkgname,
         dynamic = dynamic,  # TODO(ah) refine with dynamic projections
         import_dirs = import_artifacts,

--- a/haskell/library_info.bzl
+++ b/haskell/library_info.bzl
@@ -27,6 +27,8 @@ HaskellLibraryInfo = record(
     db = Artifact,
     # package config database, referring to the empty lib which is only used for compilation
     empty_db = Artifact,
+    # pacakge config database, used for ghc -M
+    deps_db = Artifact,
     # e.g. "base-4.13.0.0"
     id = str,
     # dynamic dependency information
@@ -58,6 +60,9 @@ def _project_as_package_db(lib: HaskellLibraryInfo):
 def _project_as_empty_package_db(lib: HaskellLibraryInfo):
   return cmd_args(lib.empty_db)
 
+def _project_as_deps_package_db(lib: HaskellLibraryInfo):
+  return cmd_args(lib.deps_db)
+
 def _get_package_deps(children: list[list[str]], lib: HaskellLibraryInfo | None):
     flatted = flatten(children)
     if lib:
@@ -68,6 +73,7 @@ HaskellLibraryInfoTSet = transitive_set(
     args_projections = {
         "package_db": _project_as_package_db,
         "empty_package_db": _project_as_empty_package_db,
+        "deps_package_db": _project_as_deps_package_db,
     },
     reductions = {
         "packages": _get_package_deps,


### PR DESCRIPTION
Using multiple source directories results in multiple entries in the `import-dirs` field of the package conf file.

With multiple entries in that field, GHC tries to find all interface files for the exposed modules (see [1] and [2]).

For the dependency analysis we do not want to depend on any interface files. To make this work we have to ensure there only is a single entry. But also, the multiple entries are needed for compilation (using the empty package dbs). That is why yet another package db is introduced here.

[1]: https://gitlab.haskell.org/ghc/ghc/-/blob/3a145315052d6f66f9682ecff87b522011165d59/compiler/GHC/Unit/Finder.hs#L491-499
[2]: https://github.com/tweag/mercury-ghc-internal/issues/51


