### PR TITLE
Fix missing srcs_envs in haskell_binary

### DIFF
--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -47,6 +47,7 @@ haskell_binary = prelude_rule(
         native_common.link_style() |
         haskell_common.srcs_arg() |
         haskell_common.external_tools_arg() |
+        haskell_common.srcs_envs_arg () |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |


### PR DESCRIPTION
haskell_binary should have the same attribute.