### PR TITLE
compiler_flags should be of attrs.arg() type

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -31,7 +31,7 @@ def _deps_arg():
 
 def _compiler_flags_arg():
     return {
-        "compiler_flags": attrs.list(attrs.string(), default = [], doc = """
+        "compiler_flags": attrs.list(attrs.arg(), default = [], doc = """
     Flags to pass to the Haskell compiler when compiling this rule's sources.
 """),
     }


### PR DESCRIPTION
compiler_flags often needs macro like `$(location :target)`. 