### PR TITLE
Use --show-iface-abi-hash for extracting hash

### DIFF
--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -131,7 +131,7 @@ def recompute_abi_hash(ghc, abi_out):
     """Call ghc on the hi file and write the ABI hash to abi_out."""
     hi_file = abi_out.with_suffix("")
 
-    cmd = [ghc, "--show-iface-abi-hash", hi_file]
+    cmd = [ghc, "-v0", "-package-env=-", "--show-iface-abi-hash", hi_file]
 
     hash = subprocess.check_output(cmd, text=True).split(maxsplit=1)[0]
 

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -131,13 +131,12 @@ def recompute_abi_hash(ghc, abi_out):
     """Call ghc on the hi file and write the ABI hash to abi_out."""
     hi_file = abi_out.with_suffix("")
 
-    cmd = [ghc, "--show-iface", hi_file]
-    for line in subprocess.check_output(cmd, text=True).splitlines():
-        if "ABI hash:" in line:
-            hash = line.split(":", 1)[1]
-            with open(abi_out, "w") as outfile:
-                print(hash, file=outfile)
-            return
+    cmd = [ghc, "--show-iface-abi-hash", hi_file]
+    for line in subprocess.check_output(cmd, text=True):
+        hash = line[0]
+        with open(abi_out, "w") as outfile:
+            print(hash, file=outfile)
+        return
     raise RuntimeError("ABI hash not found in ghc output")
 
 

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -132,12 +132,10 @@ def recompute_abi_hash(ghc, abi_out):
     hi_file = abi_out.with_suffix("")
 
     cmd = [ghc, "--show-iface-abi-hash", hi_file]
-    for line in subprocess.check_output(cmd, text=True):
-        hash = line[0]
-        with open(abi_out, "w") as outfile:
-            print(hash, file=outfile)
-        return
-    raise RuntimeError("ABI hash not found in ghc output")
+
+    hash = subprocess.check_output(cmd, text=True).split(maxsplit=1)[0]
+
+    abi_out.write_text(hash)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
supersedes #33

- **use --show-iface-abi-hash for extracting hash**
- **fix bug, and make it concise.**
- **Prevent loading of default package environment, suppress messages**
