### PR TITLE
Generating dependency graph should include boot files

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -450,7 +450,11 @@ def _make_package(
 
         source_prefixes = get_source_prefixes(ctx.attrs.srcs, module_map)
 
-        modules = filter(lambda x: not (x.endswith("-boot")), md["module_graph"].keys())
+        modules = [
+            module
+            for module in md["module_graph"].keys()
+            if not module.endswith("-boot")
+        ]
 
         # XXX use a single import dir when this package db is used for resolving dependencies with ghc -M,
         #     which works around an issue with multiple import dirs resulting in GHC trying to locate interface files

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -450,11 +450,7 @@ def _make_package(
 
         source_prefixes = get_source_prefixes(ctx.attrs.srcs, module_map)
 
-        modules = [
-            module
-            for module in md["module_graph"].keys()
-            if not module.endswith("-boot")
-        ]
+        modules = filter(lambda x: not (x.endswith("-boot")), md["module_graph"].keys())
 
         # XXX use a single import dir when this package db is used for resolving dependencies with ghc -M,
         #     which works around an issue with multiple import dirs resulting in GHC trying to locate interface files

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -189,7 +189,8 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
     with tempfile.TemporaryDirectory() as dname:
         json_fname = os.path.join(dname, "depends.json")
         make_fname = os.path.join(dname, "depends.make")
-        haskell_sources = list(filter(lambda x: is_haskell_src(x) or is_haskell_boot(x), sources))
+        haskell_sources = list(filter(is_haskell_src, sources))
+        haskell_boot_sources = list(filter (is_haskell_boot, sources))
         args = [
             ghc, "-M", "-include-pkg-deps",
             # Note: `-outputdir '.'` removes the prefix of all targets:
@@ -197,7 +198,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             "-outputdir", ".",
             "-dep-json", json_fname,
             "-dep-makefile", make_fname,
-        ] + ghc_args + haskell_sources
+        ] + ghc_args + haskell_sources + haskell_boot_sources
 
         env = os.environ.copy()
         path = env.get("PATH", "")

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -142,7 +142,7 @@ def determine_module_mapping(ghc_depends, source_prefix):
             if len(boot_sources) != 1:
                 raise RuntimeError(f"Expected at most one Haskell boot file for module '{modname}' but got '{boot_sources}'.")
 
-            boot_apparent_name = src_to_module_name(strip_prefix_(source_prefix, sources[0]).lstrip("/")) + "-boot"
+            boot_apparent_name = src_to_module_name(strip_prefix_(source_prefix, boot_sources[0].replace(".hs-boot", ".hs")).lstrip("/")) + "-boot"
 
             if boot_apparent_name != boot_modname:
                 result[boot_apparent_name] = boot_modname

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -142,7 +142,7 @@ def determine_module_mapping(ghc_depends, source_prefix):
             if len(boot_sources) != 1:
                 raise RuntimeError(f"Expected at most one Haskell boot file for module '{modname}' but got '{boot_sources}'.")
 
-            boot_apparent_name = src_to_module_name(strip_prefix_(source_prefix, boot_sources[0].replace(".hs-boot", ".hs")).lstrip("/")) + "-boot"
+            boot_apparent_name = src_to_module_name(strip_prefix_(source_prefix, boot_sources[0]).lstrip("/")) + "-boot"
 
             if boot_apparent_name != boot_modname:
                 result[boot_apparent_name] = boot_modname

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -189,7 +189,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
     with tempfile.TemporaryDirectory() as dname:
         json_fname = os.path.join(dname, "depends.json")
         make_fname = os.path.join(dname, "depends.make")
-        haskell_sources = list(filter(is_haskell_src, sources))
+        haskell_sources = list(filter(lambda x: is_haskell_src(x) or is_haskell_boot(x), sources))
         args = [
             ghc, "-M", "-include-pkg-deps",
             # Note: `-outputdir '.'` removes the prefix of all targets:


### PR DESCRIPTION
.hs-boot, .hs, .hsc, all such files should be included in the dependency graph generation.