### PR TITLE
Introduce use_same_package_name

### DIFF
--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -188,6 +188,7 @@ haskell_library = prelude_rule(
             "linker_flags": attrs.list(attrs.arg(), default = []),
             "platform": attrs.option(attrs.string(), default = None),
             "platform_linker_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg())), default = []),
+            "use_same_package_name": attrs.bool(default = False),
         }
     ),
 )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -810,8 +810,12 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
     indexing_tsets = {}
     sub_targets = {}
 
-    libname = repr(ctx.label.path).replace("//", "_").replace("/", "_") + "_" + ctx.label.name
-    pkgname = libname.replace("_", "-")
+    if(ctx.attrs.use_same_package_name):
+      libname = ctx.label.name
+      pkgname = libname
+    else:
+      libname = repr(ctx.label.path).replace("//", "_").replace("/", "_") + "_" + ctx.label.name
+      pkgname = libname.replace("_", "-")
 
     md_file = target_metadata(
         ctx,


### PR DESCRIPTION
to use the specified name as GHC package name.

In some special cases (especially GHC boot libraries), the package name needs to be given as specified.
