### PR TITLE
WIP: Support response file for large library

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -69,6 +69,13 @@ def _srcs_envs_arg():
 """),
     }
 
+def _use_response_file_for_linker_arg():
+    return {
+        "use_response_file_for_linker": attrs.bool(default = False, doc = """
+    Use response file at linking.
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
@@ -77,4 +84,5 @@ haskell_common = struct(
     scripts_arg = _scripts_arg,
     external_tools_arg = _external_tools_arg,
     srcs_envs_arg = _srcs_envs_arg,
+    use_response_file_for_linker_arg = _use_response_file_for_linker_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -48,6 +48,7 @@ haskell_binary = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.external_tools_arg() |
         haskell_common.srcs_envs_arg () |
+        haskell_common.use_response_file_for_linker_arg () |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
@@ -168,6 +169,7 @@ haskell_library = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.external_tools_arg() |
         haskell_common.srcs_envs_arg() |
+        haskell_common.use_response_file_for_linker_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -633,13 +633,13 @@ def _build_haskell_lib(
             ctx.actions.write(
                 rsp_file.as_output(),
                 cmd_args(objects),
-                allow_args = True,
                 with_inputs = True,
             )
 
             def do_link_with_response_file(ctx, _artifacts, resolved, outputs, lib=lib, rsp_file=rsp_file):
                 link = cmd_args(haskell_toolchain.linker)
                 link.add(cmd_args(rsp_file, format = "@{}"))
+                link.hidden(objects)
                 add_common_flags(link, ctx, resolved, outputs, lib)
                 ctx.actions.run(
                     link,


### PR DESCRIPTION
added use_response_file_for_linker flag.

When it is turned on, construct link.rsp file, the content of which is a concatenated newline-delimited argument list, and pass it to GHC with @-prefix. Constructed rsp file from only objects in this implementation.
