### PR TITLE
compiler_flags : list, not list[str] in _common_compile_module_args

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -5,6 +5,8 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//utils:arglike.bzl", "ArgLike")
+
 load(
     "@prelude//cxx:preprocessor.bzl",
     "cxx_inherited_preprocessor_infos",
@@ -404,7 +406,7 @@ CommonCompileModuleArgs = record(
 def _common_compile_module_args(
     actions: AnalysisActions,
     *,
-    compiler_flags: list,
+    compiler_flags: list[ArgLike],
     ghc_wrapper: RunInfo,
     haskell_toolchain: HaskellToolchainInfo,
     resolved: dict[DynamicValue, ResolvedDynamicValue],

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -404,7 +404,7 @@ CommonCompileModuleArgs = record(
 def _common_compile_module_args(
     actions: AnalysisActions,
     *,
-    compiler_flags: list[str],
+    compiler_flags: list,
     ghc_wrapper: RunInfo,
     haskell_toolchain: HaskellToolchainInfo,
     resolved: dict[DynamicValue, ResolvedDynamicValue],


### PR DESCRIPTION
As we changed compiler_flags from attrs.string() to attrs.arg() (in #34).
I found this inconsistency after incorporating the up-to-date buck2 dynamic value.