### PR TITLE
use_argsfile_at_link to use response file for a large number of objects.

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -69,6 +69,13 @@ def _srcs_envs_arg():
 """),
     }
 
+def _use_argsfile_at_link_arg():
+    return {
+        "use_argsfile_at_link": attrs.bool(default = False, doc = """
+    Use response file at linking.
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
@@ -77,4 +84,5 @@ haskell_common = struct(
     scripts_arg = _scripts_arg,
     external_tools_arg = _external_tools_arg,
     srcs_envs_arg = _srcs_envs_arg,
+    use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -48,6 +48,7 @@ haskell_binary = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.external_tools_arg() |
         haskell_common.srcs_envs_arg () |
+        haskell_common.use_argsfile_at_link_arg () |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
@@ -168,6 +169,7 @@ haskell_library = prelude_rule(
         haskell_common.srcs_arg() |
         haskell_common.external_tools_arg() |
         haskell_common.srcs_envs_arg() |
+        haskell_common.use_argsfile_at_link_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -551,7 +551,7 @@ def _dynamic_link_shared_impl(actions, artifacts, dynamic_values, outputs, arg):
         children = [package_db[name] for name in arg.toolchain_libs if name in package_db]
     )
 
-    link_args = cmd_args() #cmd_args(arg.haskell_toolchain.linker)
+    link_args = cmd_args()
     link_cmd_args = [cmd_args(arg.haskell_toolchain.linker)]
     link_cmd_hidden = []
 
@@ -575,7 +575,6 @@ def _dynamic_link_shared_impl(actions, artifacts, dynamic_values, outputs, arg):
 
 
     if arg.use_argsfile_at_link:
-        print("USE ARGSFILES AT LINK")
         argsfile = actions.declare_output(
             "haskell_link_" + arg.artifact_suffix.replace("-", "_") + ".argsfile",
         )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -551,14 +551,16 @@ def _dynamic_link_shared_impl(actions, artifacts, dynamic_values, outputs, arg):
         children = [package_db[name] for name in arg.toolchain_libs if name in package_db]
     )
 
-    link = cmd_args(arg.haskell_toolchain.linker)
-    link.add(arg.haskell_toolchain.linker_flags)
-    link.add(arg.linker_flags)
-    link.add("-hide-all-packages")
-    link.add(cmd_args(arg.toolchain_libs, prepend = "-package"))
-    link.add(cmd_args(package_db_tset.project_as_args("package_db"), prepend="-package-db"))
-    link.add("-o", outputs[arg.lib].as_output())
-    link.add(
+    link_args = cmd_args() #cmd_args(arg.haskell_toolchain.linker)
+    link_cmd_args = [cmd_args(arg.haskell_toolchain.linker)]
+    link_cmd_hidden = []
+
+    link_args.add(arg.haskell_toolchain.linker_flags)
+    link_args.add(arg.linker_flags)
+    link_args.add("-hide-all-packages")
+    link_args.add(cmd_args(arg.toolchain_libs, prepend = "-package"))
+    link_args.add(cmd_args(package_db_tset.project_as_args("package_db"), prepend="-package-db"))
+    link_args.add(
         get_shared_library_flags(arg.linker_info.type),
         "-dynamic",
         cmd_args(
@@ -567,12 +569,27 @@ def _dynamic_link_shared_impl(actions, artifacts, dynamic_values, outputs, arg):
         ),
     )
 
-    link.add(arg.objects)
+    link_args.add(arg.objects)
 
-    link.add(cmd_args(unpack_link_args(arg.infos), prepend = "-optl"))
+    link_args.add(cmd_args(unpack_link_args(arg.infos), prepend = "-optl"))
+
+
+    if arg.use_argsfile_at_link:
+        print("USE ARGSFILES AT LINK")
+        argsfile = actions.declare_output(
+            "haskell_link_" + arg.artifact_suffix.replace("-", "_") + ".argsfile",
+        )
+        actions.write(argsfile.as_output(), link_args, allow_args = True)
+        link_cmd_args.append(cmd_args(argsfile, format = "@{}"))
+        link_cmd_hidden.append(link_args)
+    else:
+        link_cmd_args.append(link_args)
+
+    link_cmd = cmd_args(link_cmd_args, hidden = link_cmd_hidden)
+    link_cmd.add("-o", outputs[arg.lib].as_output())
 
     actions.run(
-        link,
+        link_cmd,
         category = "haskell_link" + arg.artifact_suffix.replace("-", "_"),
     )
 
@@ -653,6 +670,7 @@ def _build_haskell_lib(
                 linker_info = linker_info,
                 objects = objects,
                 toolchain_libs = toolchain_libs,
+                use_argsfile_at_link = ctx.attrs.use_argsfile_at_link,
             ),
         ))
 


### PR DESCRIPTION
Reworked #41 after rebasing on top of up-to-date upstream prelude.