### PR TITLE
Import changes from upstream prelude

### DIFF
--- a/cxx/anon_link.bzl
+++ b/cxx/anon_link.bzl
@@ -10,7 +10,11 @@ load(
     "ArtifactInfo",
     "make_artifact_tset",
 )
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 load("@prelude//cxx:cxx_utility.bzl", "cxx_attrs_get_allow_cache_upload")
 load("@prelude//linking:execution_preference.bzl", "LinkExecutionPreference")
 load(
@@ -34,7 +38,7 @@ def _serialize_linkable(linkable):
         return ("archive", (
             (linkable.archive.artifact, linkable.archive.external_objects),
             linkable.link_whole,
-            linkable.linker_type,
+            linkable.linker_type.value,
             linkable.supports_lto,
         ))
 
@@ -42,7 +46,7 @@ def _serialize_linkable(linkable):
         return ("objects", (
             linkable.objects,
             linkable.link_whole,
-            linkable.linker_type,
+            linkable.linker_type.value,
         ))
 
     if isinstance(linkable, SharedLibLinkable):
@@ -107,7 +111,7 @@ def _deserialize_linkable(linkable: (str, typing.Any)) -> typing.Any:
                 external_objects = external_objects,
             ),
             link_whole = link_whole,
-            linker_type = linker_type,
+            linker_type = LinkerType(linker_type),
             supports_lto = supports_lto,
         )
 
@@ -116,7 +120,7 @@ def _deserialize_linkable(linkable: (str, typing.Any)) -> typing.Any:
         return ObjectsLinkable(
             objects = objects,
             link_whole = link_whole,
-            linker_type = linker_type,
+            linker_type = LinkerType(linker_type),
         )
 
     if typ == "shared":
@@ -207,7 +211,7 @@ ANON_ATTRS = {
                                         # ObjectsLinkable
                                         attrs.list(attrs.source()),  # objects
                                         attrs.bool(),  # link_whole
-                                        attrs.string(),  # linker_type
+                                        attrs.enum(LinkerType.values()),  # linker_type
                                     ),
                                     attrs.tuple(
                                         # ArchiveLinkable
@@ -217,7 +221,7 @@ ANON_ATTRS = {
                                             attrs.list(attrs.source()),  # external_objects
                                         ),
                                         attrs.bool(),  # link_whole
-                                        attrs.string(),  # linker_type
+                                        attrs.enum(LinkerType.values()),  # linker_type
                                         attrs.bool(),  # supports_lto
                                     ),
                                     attrs.tuple(

--- a/cxx/archive.bzl
+++ b/cxx/archive.bzl
@@ -5,7 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerInfo")
+load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerInfo", "LinkerType")
 load("@prelude//linking:link_info.bzl", "Archive")
 load("@prelude//utils:argfile.bzl", "at_argfile")
 load("@prelude//utils:utils.bzl", "value_or")
@@ -13,7 +13,7 @@ load(":cxx_context.bzl", "get_cxx_toolchain_info")
 
 def _archive_flags(
         archiver_type: str,
-        linker_type: str,
+        linker_type: LinkerType,
         use_archiver_flags: bool,
         symbol_table: bool,
         thin: bool) -> list[str]:
@@ -43,7 +43,7 @@ def _archive_flags(
         flags += "T"
 
     # GNU archivers support generating deterministic archives.
-    if linker_type == "gnu":
+    if linker_type == LinkerType("gnu"):
         flags += "D"
 
     return [flags]

--- a/cxx/cxx_library.bzl
+++ b/cxx/cxx_library.bzl
@@ -150,7 +150,12 @@ load(
     "cxx_use_shlib_intfs",
     "cxx_use_shlib_intfs_mode",
 )
-load(":cxx_toolchain_types.bzl", "ShlibInterfacesMode", "is_bitcode_format")
+load(
+    ":cxx_toolchain_types.bzl",
+    "LinkerType",
+    "ShlibInterfacesMode",
+    "is_bitcode_format",
+)
 load(
     ":cxx_types.bzl",
     "CxxRuleConstructorParams",  # @unused Used as a type
@@ -1173,7 +1178,7 @@ def _strip_objects(ctx: AnalysisContext, objects: list[Artifact]) -> list[Artifa
 
     # Stripping is not supported on Windows
     linker_type = cxx_toolchain_info.linker_info.type
-    if linker_type == "windows":
+    if linker_type == LinkerType("windows"):
         return objects
 
     # Disable stripping if no `strip` binary was provided by the toolchain.
@@ -1373,7 +1378,7 @@ def _static_library(
     # On darwin, the linked output references the archive that contains the
     # object files instead of the originating objects.
     object_external_debug_info = []
-    if linker_type == "darwin":
+    if linker_type == LinkerType("darwin"):
         object_external_debug_info.append(archive.artifact)
         object_external_debug_info.extend(archive.external_objects)
     elif objects_have_external_debug_info:

--- a/cxx/cxx_library_utility.bzl
+++ b/cxx/cxx_library_utility.bzl
@@ -25,7 +25,11 @@ load(
     "from_named_set",
 )
 load(":cxx_context.bzl", "get_cxx_platform_info", "get_cxx_toolchain_info")
-load(":cxx_toolchain_types.bzl", "ShlibInterfacesMode")
+load(
+    ":cxx_toolchain_types.bzl",
+    "LinkerType",
+    "ShlibInterfacesMode",
+)
 load(
     ":headers.bzl",
     "cxx_attr_header_namespace",
@@ -143,7 +147,7 @@ def cxx_attr_resources(ctx: AnalysisContext) -> dict[str, ArtifactOutputs]:
     return resources
 
 def cxx_is_gnu(ctx: AnalysisContext) -> bool:
-    return get_cxx_toolchain_info(ctx).linker_info.type == "gnu"
+    return get_cxx_toolchain_info(ctx).linker_info.type == LinkerType("gnu")
 
 def cxx_use_shlib_intfs(ctx: AnalysisContext) -> bool:
     """

--- a/cxx/cxx_link_utility.bzl
+++ b/cxx/cxx_link_utility.bzl
@@ -7,7 +7,11 @@
 
 load("@prelude//:artifact_tset.bzl", "project_artifacts")
 load("@prelude//:paths.bzl", "paths")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 load("@prelude//cxx:debug.bzl", "SplitDebugMode")
 load("@prelude//cxx:linker.bzl", "get_rpath_origin")
 load("@prelude//cxx:target_sdk_version.bzl", "get_target_sdk_version_linker_flags")
@@ -42,14 +46,14 @@ def generates_split_debug(toolchain: CxxToolchainInfo):
 
 def linker_map_args(toolchain: CxxToolchainInfo, linker_map) -> LinkArgs:
     linker_type = toolchain.linker_info.type
-    if linker_type == "darwin":
+    if linker_type == LinkerType("darwin"):
         flags = [
             "-Xlinker",
             "-map",
             "-Xlinker",
             linker_map,
         ]
-    elif linker_type == "gnu":
+    elif linker_type == LinkerType("gnu"):
         flags = [
             "-Xlinker",
             "-Map",
@@ -98,7 +102,7 @@ def make_link_args(
     linker_info = cxx_toolchain_info.linker_info
     linker_type = linker_info.type
 
-    if linker_type == "darwin":
+    if linker_type == LinkerType("darwin"):
         # Darwin requires a target triple specified to
         # control the deployment target being linked for.
         args.add(get_target_sdk_version_linker_flags(ctx))
@@ -132,7 +136,7 @@ def make_link_args(
         hidden.append(pdb_artifact.as_output())
 
     filelists = None
-    if linker_type == "darwin":
+    if linker_type == LinkerType("darwin"):
         filelists = filter(None, [unpack_link_args_filelist(link) for link in links])
         hidden.extend(filelists)
 
@@ -196,7 +200,7 @@ def cxx_sanitizer_runtime_arguments(
     if not linker_info.sanitizer_runtime_files:
         fail("C++ sanitizer runtime enabled but there are no runtime files")
 
-    if linker_info.type == "darwin":
+    if linker_info.type == LinkerType("darwin"):
         # ignore_artifacts as the runtime directory is not required at _link_ time
         runtime_rpath = cmd_args(ignore_artifacts = True)
         runtime_files = linker_info.sanitizer_runtime_files
@@ -247,7 +251,7 @@ def executable_shared_lib_arguments(
     linker_type = cxx_toolchain.linker_info.type
 
     if len(shared_libs) > 0:
-        if linker_type == "windows":
+        if linker_type == LinkerType("windows"):
             shared_libs_symlink_tree = [ctx.actions.symlink_file(
                 shlib.lib.output.basename,
                 shlib.lib.output,

--- a/cxx/cxx_toolchain_types.bzl
+++ b/cxx/cxx_toolchain_types.bzl
@@ -7,7 +7,7 @@
 
 load("@prelude//cxx:debug.bzl", "SplitDebugMode")
 
-LinkerType = ["gnu", "darwin", "windows", "wasm"]
+LinkerType = enum("gnu", "darwin", "windows", "wasm")
 
 ShlibInterfacesMode = enum("disabled", "enabled", "defined_only", "stub_from_library", "stub_from_headers")
 
@@ -64,7 +64,7 @@ LinkerInfo = provider(
         "requires_objects": provider_field(typing.Any, default = None),
         "supports_distributed_thinlto": provider_field(typing.Any, default = None),
         "independent_shlib_interface_linker_flags": provider_field(typing.Any, default = None),
-        "type": provider_field(typing.Any, default = None),  # of "LinkerType" type
+        "type": LinkerType,
         "use_archiver_flags": provider_field(typing.Any, default = None),
         "force_full_hybrid_if_capable": provider_field(typing.Any, default = None),
         "is_pdb_generated": provider_field(typing.Any, default = None),  # bool

--- a/cxx/headers.bzl
+++ b/cxx/headers.bzl
@@ -6,6 +6,7 @@
 # of this source tree.
 
 load("@prelude//:paths.bzl", "paths")
+load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//cxx:cxx_utility.bzl", "cxx_attrs_get_allow_cache_upload")
 load("@prelude//utils:expect.bzl", "expect")
 load("@prelude//utils:lazy.bzl", "lazy")
@@ -334,7 +335,7 @@ def _get_dict_header_namespace(namespace: str, naming: CxxHeadersNaming) -> str:
 
 def _get_debug_prefix_args(ctx: AnalysisContext, header_dir: Artifact) -> [cmd_args, None]:
     # NOTE(@christylee): Do we need to enable debug-prefix-map for darwin and windows?
-    if get_cxx_toolchain_info(ctx).linker_info.type != "gnu":
+    if get_cxx_toolchain_info(ctx).linker_info.type != LinkerType("gnu"):
         return None
 
     fmt = "-fdebug-prefix-map={}=" + value_or(header_dir.owner.cell, ".")

--- a/cxx/link.bzl
+++ b/cxx/link.bzl
@@ -16,7 +16,11 @@ load(
     "bolt",
     "cxx_use_bolt",
 )
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 load(
     "@prelude//cxx/dist_lto:darwin_dist_lto.bzl",
     "cxx_darwin_dist_link",
@@ -146,7 +150,7 @@ def cxx_link_into(
             fail("Cannot use distributed thinlto with sanitizer runtime")
 
         linker_type = linker_info.type
-        if linker_type == "darwin":
+        if linker_type == LinkerType("darwin"):
             exe = cxx_darwin_dist_link(
                 ctx,
                 output,
@@ -155,7 +159,7 @@ def cxx_link_into(
                 should_generate_dwp,
                 is_result_executable,
             )
-        elif linker_type == "gnu":
+        elif linker_type == LinkerType("gnu"):
             exe = cxx_gnu_dist_link(
                 ctx,
                 output,
@@ -246,7 +250,7 @@ def cxx_link_into(
 
     all_link_args.add(link_cmd_parts.post_linker_flags)
 
-    if linker_info.type == "windows":
+    if linker_info.type == LinkerType("windows"):
         shell_quoted_args = cmd_args(all_link_args)
     else:
         shell_quoted_args = cmd_args(all_link_args, quote = "shell")

--- a/cxx/omnibus.bzl
+++ b/cxx/omnibus.bzl
@@ -6,7 +6,11 @@
 # of this source tree.
 
 load("@prelude//:local_only.bzl", "get_resolved_cxx_binary_link_execution_preference")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "PicBehavior")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "LinkerType",
+    "PicBehavior",
+)
 load(
     "@prelude//cxx:link.bzl",
     "CxxLinkResult",  # @unused Used as a type
@@ -513,7 +517,7 @@ def _create_omnibus(
 
     # Add global symbols version script.
     # FIXME(agallagher): Support global symbols for darwin.
-    if linker_info.type != "darwin":
+    if linker_info.type != LinkerType("darwin"):
         global_sym_vers = _create_global_symbols_version_script(
             ctx,
             # Extract symbols from roots...

--- a/cxx/prebuilt_cxx_library_group.bzl
+++ b/cxx/prebuilt_cxx_library_group.bzl
@@ -5,7 +5,11 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//cxx:cxx_toolchain_types.bzl", "PicBehavior")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "LinkerType",
+    "PicBehavior",
+)
 load(
     "@prelude//cxx:preprocessor.bzl",
     "CPreprocessor",
@@ -113,7 +117,7 @@ def _parse_macro(arg: str) -> [(str, str), None]:
 
 def _get_static_link_infos(
         ctx: AnalysisContext,
-        linker_type: str,
+        linker_type: LinkerType,
         libs: list[Artifact],
         args: list[str]) -> LinkInfos:
     """

--- a/cxx/symbols.bzl
+++ b/cxx/symbols.bzl
@@ -6,7 +6,11 @@
 # of this source tree.
 
 load("@prelude//:paths.bzl", "paths")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 load("@prelude//cxx:cxx_utility.bzl", "cxx_attrs_get_allow_cache_upload")
 load("@prelude//os_lookup:defs.bzl", "OsLookup")
 
@@ -48,7 +52,7 @@ def _extract_symbol_names(
         nm_flags += "u"
 
     # darwin objects don't have dynamic symbol tables.
-    if dynamic and cxx_toolchain.linker_info.type != "darwin":
+    if dynamic and cxx_toolchain.linker_info.type != LinkerType("darwin"):
         nm_flags += "D"
 
     # llvm-nm supports -U for this but gnu nm doesn't.
@@ -314,7 +318,7 @@ def get_undefined_symbols_args(
         category: [str, None] = None,
         identifier: [str, None] = None,
         prefer_local: bool = False) -> cmd_args:
-    if cxx_toolchain.linker_info.type == "gnu":
+    if cxx_toolchain.linker_info.type == LinkerType("gnu"):
         # linker script is only supported in gnu linkers
         linker_script = create_undefined_symbols_linker_script(
             ctx.actions,

--- a/cxx/user/cxx_toolchain_override.bzl
+++ b/cxx/user/cxx_toolchain_override.bzl
@@ -5,7 +5,23 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//cxx:cxx_toolchain_types.bzl", "AsCompilerInfo", "AsmCompilerInfo", "BinaryUtilitiesInfo", "CCompilerInfo", "CxxCompilerInfo", "CxxObjectFormat", "CxxPlatformInfo", "CxxToolchainInfo", "LinkerInfo", "LinkerType", "PicBehavior", "ShlibInterfacesMode", "StripFlagsInfo", "cxx_toolchain_infos")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "AsCompilerInfo",
+    "AsmCompilerInfo",
+    "BinaryUtilitiesInfo",
+    "CCompilerInfo",
+    "CxxCompilerInfo",
+    "CxxObjectFormat",
+    "CxxPlatformInfo",
+    "CxxToolchainInfo",
+    "LinkerInfo",
+    "LinkerType",
+    "PicBehavior",
+    "ShlibInterfacesMode",
+    "StripFlagsInfo",
+    "cxx_toolchain_infos",
+)
 load("@prelude//cxx:cxx_utility.bzl", "cxx_toolchain_allow_cache_upload_args")
 load("@prelude//cxx:debug.bzl", "SplitDebugMode")
 load("@prelude//cxx:headers.bzl", "HeaderMode")
@@ -68,7 +84,7 @@ def _cxx_toolchain_override(ctx):
         allow_cache_upload = _pick_raw(ctx.attrs.cxx_compiler_allow_cache_upload, base_cxx_info.allow_cache_upload),
     )
     base_linker_info = base_toolchain.linker_info
-    linker_type = ctx.attrs.linker_type if ctx.attrs.linker_type != None else base_linker_info.type
+    linker_type = LinkerType(ctx.attrs.linker_type) if ctx.attrs.linker_type != None else base_linker_info.type
     pdb_expected = is_pdb_generated(linker_type, ctx.attrs.linker_flags) if ctx.attrs.linker_flags != None else base_linker_info.is_pdb_generated
 
     # This handles case when linker type is overridden to non-windows from
@@ -77,7 +93,7 @@ def _cxx_toolchain_override(ctx):
     # we can't inspect base linker flags and disable PDB subtargets.
     # This shouldn't be a problem because to use windows linker after non-windows
     # linker flags should be changed as well.
-    pdb_expected = linker_type == "windows" and pdb_expected
+    pdb_expected = linker_type == LinkerType("windows") and pdb_expected
     shlib_interfaces = ShlibInterfacesMode(ctx.attrs.shared_library_interface_mode) if ctx.attrs.shared_library_interface_mode else None
     sanitizer_runtime_files = flatten([runtime_file[DefaultInfo].default_outputs for runtime_file in ctx.attrs.sanitizer_runtime_files]) if ctx.attrs.sanitizer_runtime_files != None else None
     linker_info = LinkerInfo(
@@ -206,7 +222,7 @@ cxx_toolchain_override_registration_spec = RuleRegistrationSpec(
         "link_weight": attrs.option(attrs.int(), default = None),
         "linker": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
         "linker_flags": attrs.option(attrs.list(attrs.arg()), default = None),
-        "linker_type": attrs.option(attrs.enum(LinkerType), default = None),
+        "linker_type": attrs.option(attrs.enum(LinkerType.values()), default = None),
         "llvm_link": attrs.option(attrs.exec_dep(providers = [RunInfo]), default = None),
         "lto_mode": attrs.option(attrs.enum(LtoMode.values()), default = None),
         "min_sdk_version": attrs.option(attrs.string(), default = None),

--- a/decls/common.bzl
+++ b/decls/common.bzl
@@ -20,7 +20,7 @@ prelude_rule = record(
     further = field([str, None], None),
     attrs = field(dict[str, Attr]),
     impl = field([typing.Callable, None], None),
-    uses_plugins = field([list["PluginKind"], None], None),
+    uses_plugins = field([list[plugins.PluginKind], None], None),
 )
 
 AbiGenerationMode = ["unknown", "class", "source", "migrating_to_source_only", "source_only", "unrecognized"]

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -348,23 +348,17 @@ def get_packages_info2(
     exposed_package_args = cmd_args([package_flag, "base"])
 
     if for_deps:
-        package_db_projection = "deps_package_db"
+        get_db = lambda l: l.deps_db
     elif use_empty_lib:
-        package_db_projection = "empty_package_db"
+        get_db = lambda l: l.empty_db
     else:
-        package_db_projection = "package_db"
+        get_db = lambda l: l.db
 
     packagedb_args = cmd_args()
     packagedb_set = {}
 
     for lib in libs.traverse():
-        if for_deps:
-            db = lib.deps_db
-        elif use_empty_lib:
-            db = lib.empty_db
-        else:
-            db = lib.db
-        packagedb_set[db] = None
+        packagedb_set[get_db(lib)] = None
         hidden_args = cmd_args(hidden = [
             lib.import_dirs.values(),
             lib.stub_dirs,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -229,11 +229,7 @@ def target_metadata(
     md_gen = ctx.attrs._generate_target_metadata[RunInfo]
 
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-    toolchain_libs = [
-        dep[HaskellToolchainLibrary].name
-        for dep in ctx.attrs.deps
-        if HaskellToolchainLibrary in dep
-    ]
+    toolchain_libs = [dep.name for dep in attr_deps_haskell_toolchain_libraries(ctx)]
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -101,7 +101,6 @@ CompileResultInfo = record(
 )
 
 PackagesInfo = record(
-    exposed_package_libs = cmd_args,
     exposed_package_args = cmd_args,
     packagedb_args = cmd_args,
     transitive_deps = field(HaskellLibraryInfoTSet),
@@ -340,7 +339,6 @@ def get_packages_info2(
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)
 
-    exposed_package_libs = cmd_args()
     exposed_package_args = cmd_args([package_flag, "base"])
 
     if for_deps:
@@ -399,7 +397,6 @@ def get_packages_info2(
         exposed_package_args.add(package_flag, pkg_name)
 
     return PackagesInfo(
-        exposed_package_libs = exposed_package_libs,
         exposed_package_args = exposed_package_args,
         packagedb_args = packagedb_args,
         transitive_deps = libs,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -50,6 +50,7 @@ load(
     "@prelude//linking:link_info.bzl",
     "LinkStyle",
 )
+load("@prelude//utils:argfile.bzl", "at_argfile")
 load("@prelude//:paths.bzl", "paths")
 load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
 load("@prelude//utils:strings.bzl", "strip_prefix")
@@ -654,12 +655,12 @@ def _compile_module(
                 format="--extra-env-value={}",
             ))
     if haskell_toolchain.use_argsfile:
-        argsfile = actions.declare_output(
-            "haskell_compile_" + artifact_suffix + ".argsfile",
-        )
-        actions.write(argsfile.as_output(), compile_args_for_file, allow_args = True)
-        compile_cmd_args.append(cmd_args(argsfile, format = "@{}"))
-        compile_cmd_hidden.append(compile_args_for_file)
+        compile_cmd_args.append(at_argfile(
+            actions = actions,
+            name = "haskell_compile_" + artifact_suffix + ".argsfile",
+            args = compile_args_for_file,
+            allow_args = True,
+        ))
     else:
         compile_cmd_args.append(compile_args_for_file)
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -422,8 +422,6 @@ def _common_compile_module_args(
     direct_deps_info: list[HaskellLibraryInfoTSet],
     pkgname: str | None = None,
 ) -> CommonCompileModuleArgs:
-    #haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-
     command = cmd_args(ghc_wrapper)
     command.add("--ghc", haskell_toolchain.compiler)
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -331,10 +331,13 @@ def get_packages_info2(
 
     # Collect library dependencies. Note that these don't need to be in a
     # particular order.
-    libs = actions.tset(HaskellLibraryInfoTSet, children = [
-        lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
-        for lib in direct_deps_link_info
-    ])
+    libs = actions.tset(
+        HaskellLibraryInfoTSet,
+        children = [
+            lib.prof_info[link_style] if enable_profiling else lib.info[link_style]
+            for lib in direct_deps_link_info
+        ],
+    )
 
     # base is special and gets exposed by default
     package_flag = _package_flag(haskell_toolchain)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -21,6 +21,7 @@ load(
 load(
     "@prelude//cxx:cxx_toolchain_types.bzl",
     "CxxToolchainInfo",
+    "LinkerType",
     "PicBehavior",
 )
 load("@prelude//cxx:groups.bzl", "get_dedupped_roots_from_groups")
@@ -267,7 +268,7 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
         def archive_linkable(lib):
             return ArchiveLinkable(
                 archive = Archive(artifact = lib),
-                linker_type = "gnu",
+                linker_type = LinkerType("gnu"),
             )
 
         def shared_linkable(lib):
@@ -535,10 +536,12 @@ HaskellLibBuildOutput = record(
     libs = list[Artifact],
 )
 
-def _get_haskell_shared_library_name_linker_flags(linker_type: str, soname: str) -> list[str]:
-    if linker_type == "gnu":
+def _get_haskell_shared_library_name_linker_flags(
+        linker_type: LinkerType,
+        soname: str) -> list[str]:
+    if linker_type == LinkerType("gnu"):
         return ["-Wl,-soname,{}".format(soname)]
-    elif linker_type == "darwin":
+    elif linker_type == LinkerType("darwin"):
         # Passing `-install_name @rpath/...` or
         # `-Xlinker -install_name -Xlinker @rpath/...` instead causes
         # ghc-9.6.3: panic! (the 'impossible' happened)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -366,7 +366,7 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
 
     inherited_pp_info = cxx_inherited_preprocessor_infos(ctx.attrs.deps)
     own_pp_info = CPreprocessor(
-        relative_args = CPreprocessorArgs(args = flatten([["-isystem", d] for d in ctx.attrs.cxx_header_dirs])),
+        args = CPreprocessorArgs(args = flatten([["-isystem", d] for d in ctx.attrs.cxx_header_dirs])),
     )
 
     return [

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1144,8 +1144,6 @@ def _dynamic_link_binary_impl(actions, artifacts, dynamic_values, outputs, arg):
     link_cmd.add(arg.haskell_toolchain.linker_flags)
     link_cmd.add(arg.linker_flags)
 
-    link_cmd.add(cmd_args(hidden = packages_info.exposed_package_libs))
-
     link_cmd.add("-o", outputs[arg.output].as_output())
 
     actions.run(link_cmd, category = "haskell_link")

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -285,15 +285,17 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
         ]
 
         hlibinfos[link_style] = hlibinfo
-        hlinkinfos[link_style] = ctx.actions.tset(HaskellLibraryInfoTSet, value = hlibinfo, children = [
-            lib.info[link_style]
-            for lib in haskell_infos
-        ])
+        hlinkinfos[link_style] = ctx.actions.tset(
+            HaskellLibraryInfoTSet,
+            value = hlibinfo,
+            children = [lib.info[link_style] for lib in haskell_infos],
+        )
         prof_hlibinfos[link_style] = prof_hlibinfo
-        prof_hlinkinfos[link_style] = ctx.actions.tset(HaskellLibraryInfoTSet, value = prof_hlibinfo, children = [
-            lib.prof_info[link_style]
-            for lib in haskell_infos
-        ])
+        prof_hlinkinfos[link_style] = ctx.actions.tset(
+            HaskellLibraryInfoTSet,
+            value = prof_hlibinfo,
+            children = [lib.prof_info[link_style] for lib in haskell_infos],
+        )
         link_infos[link_style] = LinkInfos(
             default = LinkInfo(
                 pre_flags = ctx.attrs.exported_linker_flags,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -638,7 +638,9 @@ def _build_haskell_lib(
 
     linfos = [x.prof_info if enable_profiling else x.info for x in hlis]
 
+    # only gather direct dependencies
     uniq_infos = [x[link_style].value for x in linfos]
+
     toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
 
     if link_style == LinkStyle("shared"):
@@ -1088,7 +1090,9 @@ def _make_link_package(
     pkg_conf = ctx.actions.write("pkg-" + artifact_suffix + "_link.conf", conf)
     db = ctx.actions.declare_output("db-" + artifact_suffix + "_link", dir = True)
 
-    db_deps = [x.db for x in hlis]
+    # While the list of hlis is unique, there may be multiple packages in the same db.
+    # Cutting down the GHC_PACKAGE_PATH significantly speeds up GHC.
+    db_deps = {x.db: None for x in hlis}.keys()
 
     # So that ghc-pkg can find the DBs for the dependencies. We might
     # be able to use flags for this instead, but this works.

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -87,6 +87,7 @@ load(
     "attr_deps_haskell_link_infos_sans_template_deps",
     "attr_deps_haskell_lib_infos",
     "attr_deps_haskell_link_infos",
+    "attr_deps_haskell_toolchain_libraries",
     "attr_deps_merged_link_infos",
     "attr_deps_profiling_link_infos",
     "attr_deps_shared_library_infos",
@@ -641,7 +642,7 @@ def _build_haskell_lib(
     # only gather direct dependencies
     uniq_infos = [x[link_style].value for x in linfos]
 
-    toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
+    toolchain_libs = [dep.name for dep in attr_deps_haskell_toolchain_libraries(ctx)] 
 
     if link_style == LinkStyle("shared"):
         lib = ctx.actions.declare_output(lib_short_path)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -146,6 +146,7 @@ load(
     "@prelude//python:python.bzl",
     "PythonLibraryInfo",
 )
+load("@prelude//utils:argfile.bzl", "at_argfile")
 load("@prelude//utils:set.bzl", "set")
 load("@prelude//utils:utils.bzl", "filter_and_map_idx", "flatten")
 
@@ -573,14 +574,13 @@ def _dynamic_link_shared_impl(actions, artifacts, dynamic_values, outputs, arg):
 
     link_args.add(cmd_args(unpack_link_args(arg.infos), prepend = "-optl"))
 
-
     if arg.use_argsfile_at_link:
-        argsfile = actions.declare_output(
-            "haskell_link_" + arg.artifact_suffix.replace("-", "_") + ".argsfile",
-        )
-        actions.write(argsfile.as_output(), link_args, allow_args = True)
-        link_cmd_args.append(cmd_args(argsfile, format = "@{}"))
-        link_cmd_hidden.append(link_args)
+        link_cmd_args.append(at_argfile(
+            actions = actions,
+            name = "haskell_link_" + arg.artifact_suffix.replace("-", "_") + ".argsfile",
+            args = link_args,
+            allow_args = True,
+        ))
     else:
         link_cmd_args.append(link_args)
 

--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -43,6 +43,7 @@ load(
 )
 load(
     "@prelude//linking:linkable_graph.bzl",
+    "LinkableGraph",
     "LinkableRootInfo",
     "create_linkable_graph",
     "get_deps_for_link",
@@ -183,7 +184,11 @@ def _build_haskell_omnibus_so(ctx: AnalysisContext) -> HaskellOmnibusData:
         for nlabel, n in graph_nodes.items()
     }
 
-    all_direct_deps = [dep.label for dep in all_deps]
+    all_direct_deps = []
+    for dep in all_deps:
+        graph = dep.get(LinkableGraph)
+        if graph:
+            all_direct_deps.append(graph.label)
     dep_graph[ctx.label] = all_direct_deps
 
     # Need to exclude all transitive deps of excluded deps
@@ -346,16 +351,16 @@ def _replace_macros_in_script_template(
         # Optional string args
         srcs: [str, None] = None,
         output_name: [str, None] = None,
-        ghci_iserv_path: [str, None] = None,
+        ghci_iserv_path: [Artifact, None] = None,
         preload_libs: [str, None] = None) -> Artifact:
     toolchain_paths = {
         BINUTILS_PATH: haskell_toolchain.ghci_binutils_path,
-        GHCI_LIB_PATH: haskell_toolchain.ghci_lib_path,
+        GHCI_LIB_PATH: haskell_toolchain.ghci_lib_path.get(DefaultInfo).default_outputs[0],
         CC_PATH: haskell_toolchain.ghci_cc_path,
         CPP_PATH: haskell_toolchain.ghci_cpp_path,
         CXX_PATH: haskell_toolchain.ghci_cxx_path,
-        GHCI_PACKAGER: haskell_toolchain.ghci_packager,
-        GHCI_GHC_PATH: haskell_toolchain.ghci_ghc_path,
+        GHCI_PACKAGER: haskell_toolchain.ghci_packager.get(DefaultInfo).default_outputs[0],
+        GHCI_GHC_PATH: haskell_toolchain.ghci_ghc_path.get(DefaultInfo).default_outputs[0],
     }
 
     if ghci_bin != None:
@@ -370,7 +375,7 @@ def _replace_macros_in_script_template(
     replace_cmd.add(cmd_args(script_template, format = "--script_template={}"))
     for name, path in toolchain_paths.items():
         if path:
-            replace_cmd.add(cmd_args("--{}={}".format(name, path)))
+            replace_cmd.add(cmd_args(path, format = "--{}={{}}".format(name)))
 
     replace_cmd.add(cmd_args(
         final_script.as_output(),
@@ -467,7 +472,7 @@ def _write_iserv_script(
         script_template = ghci_iserv_template,
         output_name = iserv_script_name,
         haskell_toolchain = haskell_toolchain,
-        ghci_iserv_path = ghci_iserv_path,
+        ghci_iserv_path = ghci_iserv_path.get(DefaultInfo).default_outputs[0],
         preload_libs = preload_libs,
     )
     return iserv_script

--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -332,6 +332,11 @@ def _build_haskell_omnibus_so(ctx: AnalysisContext) -> HaskellOmnibusData:
         so_symlinks_root = so_symlinks_root,
     )
 
+def _get_default_output(dependency: Dependency | None) -> Artifact | None:
+    if dependency == None:
+        return None
+    return dependency.get(DefaultInfo).default_outputs[0]
+
 # Use the script_template_processor.py script to generate a script from a
 # script template.
 def _replace_macros_in_script_template(
@@ -355,12 +360,12 @@ def _replace_macros_in_script_template(
         preload_libs: [str, None] = None) -> Artifact:
     toolchain_paths = {
         BINUTILS_PATH: haskell_toolchain.ghci_binutils_path,
-        GHCI_LIB_PATH: haskell_toolchain.ghci_lib_path.get(DefaultInfo).default_outputs[0],
+        GHCI_LIB_PATH: _get_default_output(haskell_toolchain.ghci_lib_path),
         CC_PATH: haskell_toolchain.ghci_cc_path,
         CPP_PATH: haskell_toolchain.ghci_cpp_path,
         CXX_PATH: haskell_toolchain.ghci_cxx_path,
-        GHCI_PACKAGER: haskell_toolchain.ghci_packager.get(DefaultInfo).default_outputs[0],
-        GHCI_GHC_PATH: haskell_toolchain.ghci_ghc_path.get(DefaultInfo).default_outputs[0],
+        GHCI_PACKAGER: _get_default_output(haskell_toolchain.ghci_packager),
+        GHCI_GHC_PATH: _get_default_output(haskell_toolchain.ghci_ghc_path),
     }
 
     if ghci_bin != None:
@@ -472,7 +477,7 @@ def _write_iserv_script(
         script_template = ghci_iserv_template,
         output_name = iserv_script_name,
         haskell_toolchain = haskell_toolchain,
-        ghci_iserv_path = ghci_iserv_path.get(DefaultInfo).default_outputs[0],
+        ghci_iserv_path = _get_default_output(ghci_iserv_path),
         preload_libs = preload_libs,
     )
     return iserv_script

--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -647,11 +647,11 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
     package_symlinks_root = ctx.label.name + ".packages"
 
     packagedb_args = cmd_args(delimiter = " ")
-    prebuilt_packagedb_args = cmd_args(delimiter = " ")
+    prebuilt_packagedb_args_set = {}
 
     for lib in packages_info.transitive_deps.traverse():
         if lib.is_prebuilt:
-            prebuilt_packagedb_args.add(lib.db)
+            prebuilt_packagedb_args_set[lib.db] = None
         else:
             lib_symlinks_root = paths.join(
                 package_symlinks_root,
@@ -682,6 +682,7 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
                     "packagedb",
                 ),
             )
+    prebuilt_packagedb_args = cmd_args(prebuilt_packagedb_args_set.keys(), delimiter = " ")
 
     script_templates = []
     for script_template in ctx.attrs.extra_script_templates:

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -190,7 +190,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
         json_fname = os.path.join(dname, "depends.json")
         make_fname = os.path.join(dname, "depends.make")
         haskell_sources = list(filter(is_haskell_src, sources))
-        haskell_boot_sources = list(filter (is_haskell_boot, sources))
+
         args = [
             ghc, "-M", "-include-pkg-deps",
             # Note: `-outputdir '.'` removes the prefix of all targets:
@@ -198,7 +198,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             "-outputdir", ".",
             "-dep-json", json_fname,
             "-dep-makefile", make_fname,
-        ] + ghc_args + haskell_sources + haskell_boot_sources
+        ] + ghc_args + haskell_sources
 
         env = os.environ.copy()
         path = env.get("PATH", "")

--- a/haskell/util.bzl
+++ b/haskell/util.bzl
@@ -78,13 +78,13 @@ def attr_deps(ctx: AnalysisContext) -> list[Dependency]:
     return ctx.attrs.deps + _by_platform(ctx, ctx.attrs.platform_deps)
 
 def attr_deps_haskell_link_infos(ctx: AnalysisContext) -> list[HaskellLinkInfo]:
-    return filter(
+    return dedupe(filter(
         None,
         [
             d.get(HaskellLinkInfo)
             for d in attr_deps(ctx) + ctx.attrs.template_deps
         ],
-    )
+    ))
 
 def attr_deps_haskell_toolchain_libraries(ctx: AnalysisContext) -> list[HaskellToolchainLibrary]:
     return filter(
@@ -97,13 +97,13 @@ def attr_deps_haskell_toolchain_libraries(ctx: AnalysisContext) -> list[HaskellT
 
 # DONT CALL THIS FUNCTION, you want attr_deps_haskell_link_infos instead
 def attr_deps_haskell_link_infos_sans_template_deps(ctx: AnalysisContext) -> list[HaskellLinkInfo]:
-    return filter(
+    return dedupe(filter(
         None,
         [
             d.get(HaskellLinkInfo)
             for d in attr_deps(ctx)
         ],
-    )
+    ))
 
 def attr_deps_haskell_lib_infos(
         ctx: AnalysisContext,
@@ -120,13 +120,13 @@ def attr_deps_haskell_lib_infos(
     ]
 
 def attr_deps_merged_link_infos(ctx: AnalysisContext) -> list[MergedLinkInfo]:
-    return filter(
+    return dedupe(filter(
         None,
         [
             d.get(MergedLinkInfo)
             for d in attr_deps(ctx)
         ],
-    )
+    ))
 
 def attr_deps_profiling_link_infos(ctx: AnalysisContext) -> list[MergedLinkInfo]:
     return filter(

--- a/linking/link_info.bzl
+++ b/linking/link_info.bzl
@@ -10,7 +10,11 @@ load(
     "ArtifactTSet",
     "make_artifact_tset",
 )
-load("@prelude//cxx:cxx_toolchain_types.bzl", "PicBehavior")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "LinkerType",
+    "PicBehavior",
+)
 load(
     "@prelude//cxx:linker.bzl",
     "get_link_whole_args",
@@ -77,7 +81,7 @@ ArchiveLinkable = record(
     archive = field(Archive),
     # If a bitcode bundle was created for this artifact it will be present here
     bitcode_bundle = field(Artifact | None, None),
-    linker_type = field(str),
+    linker_type = field(LinkerType),
     link_whole = field(bool, False),
     # Indicates if this archive may contain LTO bit code.  Can be set to `False`
     # to e.g. tell dist LTO handling that a potentially expensive archive doesn't
@@ -96,7 +100,7 @@ ObjectsLinkable = record(
     objects = field([list[Artifact], None], None),
     # Any of the objects that are in bitcode format
     bitcode_bundle = field(Artifact | None, None),
-    linker_type = field(str),
+    linker_type = field(LinkerType),
     link_whole = field(bool, False),
 )
 
@@ -900,13 +904,13 @@ def merge_swiftmodule_linkables(ctx: AnalysisContext, linkables: list[[Swiftmodu
         ],
     ))
 
-def wrap_with_no_as_needed_shared_libs_flags(linker_type: str, link_info: LinkInfo) -> LinkInfo:
+def wrap_with_no_as_needed_shared_libs_flags(linker_type: LinkerType, link_info: LinkInfo) -> LinkInfo:
     """
     Wrap link info in args used to prevent linkers from dropping unused shared
     library dependencies from the e.g. DT_NEEDED tags of the link.
     """
 
-    if linker_type == "gnu":
+    if linker_type == LinkerType("gnu"):
         return wrap_link_info(
             inner = link_info,
             pre_flags = (
@@ -916,7 +920,7 @@ def wrap_with_no_as_needed_shared_libs_flags(linker_type: str, link_info: LinkIn
             post_flags = ["-Wl,--pop-state"],
         )
 
-    if linker_type == "darwin":
+    if linker_type == LinkerType("darwin"):
         return link_info
 
     fail("Linker type {} not supported".format(linker_type))

--- a/linking/lto.bzl
+++ b/linking/lto.bzl
@@ -5,7 +5,11 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 load("@prelude//cxx:debug.bzl", "SplitDebugMode")
 
 # Styles of LTO.
@@ -50,7 +54,7 @@ def get_split_debug_lto_info(actions: AnalysisActions, cxx_toolchain: CxxToolcha
 
     # TODO: It might be nice to generalize a but more and move the darwin v. gnu
     # differences into toolchain settings (e.g. `split_debug_lto_flags_fmt`).
-    if linker_info.type == "darwin":
+    if linker_info.type == LinkerType("darwin"):
         # https://releases.llvm.org/14.0.0/tools/clang/docs/CommandGuide/clang.html#cmdoption-flto
         # We need to pass -object_path_lto to keep the temporary LTO object files around to use
         # for dSYM generation.
@@ -74,7 +78,7 @@ def get_split_debug_lto_info(actions: AnalysisActions, cxx_toolchain: CxxToolcha
             linker_flags = linker_args,
         )
 
-    if linker_info.type == "gnu":
+    if linker_info.type == LinkerType("gnu"):
         dwo_dir = actions.declare_output(name + ".dwo.d", dir = True)
 
         linker_flags = cmd_args([

--- a/linking/strip.bzl
+++ b/linking/strip.bzl
@@ -6,7 +6,11 @@
 # of this source tree.
 
 load("@prelude//cxx:cxx_context.bzl", "get_cxx_toolchain_info")
-load("@prelude//cxx:cxx_toolchain_types.bzl", "CxxToolchainInfo")
+load(
+    "@prelude//cxx:cxx_toolchain_types.bzl",
+    "CxxToolchainInfo",
+    "LinkerType",
+)
 
 def _strip_debug_info(ctx: AnalysisContext, out: str, obj: Artifact) -> Artifact:
     """
@@ -15,7 +19,7 @@ def _strip_debug_info(ctx: AnalysisContext, out: str, obj: Artifact) -> Artifact
     cxx_toolchain = get_cxx_toolchain_info(ctx)
     strip = cxx_toolchain.binary_utilities_info.strip
     output = ctx.actions.declare_output("__stripped__", out)
-    if cxx_toolchain.linker_info.type == "gnu":
+    if cxx_toolchain.linker_info.type == LinkerType("gnu"):
         cmd = cmd_args([strip, "--strip-debug", "--strip-unneeded", "-o", output.as_output(), obj])
     else:
         cmd = cmd_args([strip, "-S", "-o", output.as_output(), obj])

--- a/rust/build_params.bzl
+++ b/rust/build_params.bzl
@@ -7,6 +7,7 @@
 
 # Rules for mapping requirements to options
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load(
     "@prelude//linking:link_info.bzl",
     "LibOutputStyle",
@@ -186,20 +187,20 @@ _RUST_STATIC_NON_PIC_LIBRARY = 7
 _NATIVE_LINKABLE_STATIC_PIC = 8
 _NATIVE_LINKABLE_STATIC_NON_PIC = 9
 
-def _executable_prefix_suffix(linker_type: str, target_os_type: OsLookup) -> (str, str):
+def _executable_prefix_suffix(linker_type: LinkerType, target_os_type: OsLookup) -> (str, str):
     return {
-        "darwin": ("", ""),
-        "gnu": ("", ".exe") if target_os_type.platform == "windows" else ("", ""),
-        "wasm": ("", ".wasm"),
-        "windows": ("", ".exe"),
+        LinkerType("darwin"): ("", ""),
+        LinkerType("gnu"): ("", ".exe") if target_os_type.platform == "windows" else ("", ""),
+        LinkerType("wasm"): ("", ".wasm"),
+        LinkerType("windows"): ("", ".exe"),
     }[linker_type]
 
-def _library_prefix_suffix(linker_type: str, target_os_type: OsLookup) -> (str, str):
+def _library_prefix_suffix(linker_type: LinkerType, target_os_type: OsLookup) -> (str, str):
     return {
-        "darwin": ("lib", ".dylib"),
-        "gnu": ("", ".dll") if target_os_type.platform == "windows" else ("lib", ".so"),
-        "wasm": ("", ".wasm"),
-        "windows": ("", ".dll"),
+        LinkerType("darwin"): ("lib", ".dylib"),
+        LinkerType("gnu"): ("", ".dll") if target_os_type.platform == "windows" else ("lib", ".so"),
+        LinkerType("wasm"): ("", ".wasm"),
+        LinkerType("windows"): ("", ".dll"),
     }[linker_type]
 
 _BUILD_PARAMS = {
@@ -338,7 +339,7 @@ def build_params(
         link_strategy: LinkStrategy | None,
         lib_output_style: LibOutputStyle | None,
         lang: LinkageLang,
-        linker_type: str,
+        linker_type: LinkerType,
         target_os_type: OsLookup) -> BuildParams:
     if rule == RuleType("binary"):
         expect(link_strategy != None)

--- a/toolchains/cxx.bzl
+++ b/toolchains/cxx.bzl
@@ -14,6 +14,7 @@ load(
     "CxxPlatformInfo",
     "CxxToolchainInfo",
     "LinkerInfo",
+    "LinkerType",
     "PicBehavior",
     "RcCompilerInfo",
     "ShlibInterfacesMode",
@@ -36,7 +37,7 @@ CxxToolsInfo = provider(
         "cvtres_compiler": provider_field(typing.Any, default = None),
         "cxx_compiler": provider_field(typing.Any, default = None),
         "linker": provider_field(typing.Any, default = None),
-        "linker_type": provider_field(typing.Any, default = None),
+        "linker_type": LinkerType,
         "rc_compiler": provider_field(typing.Any, default = None),
     },
 )
@@ -90,7 +91,7 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
     additional_linker_flags = ["-fuse-ld=lld"] if os == "linux" and cxx_tools_info.linker != "g++" and cxx_tools_info.cxx_compiler != "g++" else []
 
     if os == "windows":
-        linker_type = "windows"
+        linker_type = LinkerType("windows")
         binary_extension = "exe"
         object_file_extension = "obj"
         static_library_extension = "lib"
@@ -107,10 +108,10 @@ def _cxx_toolchain_from_cxx_tools_info(ctx: AnalysisContext, cxx_tools_info: Cxx
         shared_library_versioned_name_format = "{}.so.{}"
 
         if os == "macos":
-            linker_type = "darwin"
+            linker_type = LinkerType("darwin")
             pic_behavior = PicBehavior("always_enabled")
         else:
-            linker_type = "gnu"
+            linker_type = LinkerType("gnu")
             pic_behavior = PicBehavior("supported")
 
     if cxx_tools_info.compiler_type == "clang":

--- a/toolchains/cxx/clang/tools.bzl
+++ b/toolchains/cxx/clang/tools.bzl
@@ -5,6 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 
 def _path_clang_tools_impl(_ctx) -> list[Provider]:
@@ -21,7 +22,7 @@ def _path_clang_tools_impl(_ctx) -> list[Provider]:
             archiver = "ar",
             archiver_type = "gnu",
             linker = "clang++",
-            linker_type = "gnu",
+            linker_type = LinkerType("gnu"),
         ),
     ]
 

--- a/toolchains/msvc/tools.bzl
+++ b/toolchains/msvc/tools.bzl
@@ -5,6 +5,7 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
+load("@prelude//cxx:cxx_toolchain_types.bzl", "LinkerType")
 load("@prelude//toolchains:cxx.bzl", "CxxToolsInfo")
 load("@prelude//utils:cmd_script.bzl", "ScriptOs", "cmd_script")
 
@@ -133,7 +134,7 @@ def _find_msvc_tools_impl(ctx: AnalysisContext) -> list[Provider]:
             archiver = lib_exe_script,
             archiver_type = "windows",
             linker = _windows_linker_wrapper(ctx, link_exe_script),
-            linker_type = "windows",
+            linker_type = LinkerType("windows"),
         ),
     ]
 


### PR DESCRIPTION
This PR introduces a few changes from upstream, mostly in order to reduce the amount of changes between the
current prelude and ourselves to make it easier to upstream, and to benefit from upstream changes.

- **Dedupe attribute lists of deps**
- **Use `at_argfile` helper**
- **Remove left-over comment**
- **Add performance optimisations for handling package DBs**
- **Move package db selection before the loop**
- **Use attr_deps_haskell_toolchain_libraries**
- **Remove `exposed_package_libs`**
- **Reformat**
- **Convert cxx toolchain LinkerType to enum**
- **Fix haskell_ghci() for multi-version GHC**
- **Rename relative args -> args**
