### PR TITLE
Support virtual_modules

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -76,6 +76,13 @@ def _use_argsfile_at_link_arg():
 """),
     }
 
+def _virtual_modules_arg():
+    return {
+        "virtual_modules": attrs.named_set(attrs.string(), sorted = True, default = [], doc = """
+    A list of virtual Haskell modules. See Cabal virtual-modules.
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
@@ -85,4 +92,5 @@ haskell_common = struct(
     external_tools_arg = _external_tools_arg,
     srcs_envs_arg = _srcs_envs_arg,
     use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
+    virtual_modules_arg = _virtual_modules_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -170,6 +170,7 @@ haskell_library = prelude_rule(
         haskell_common.external_tools_arg() |
         haskell_common.srcs_envs_arg() |
         haskell_common.use_argsfile_at_link_arg() |
+        haskell_common.virtual_modules_arg() |
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -190,7 +190,6 @@ def _dynamic_target_metadata_impl(actions, artifacts, dynamic_values, outputs, a
     package_flag = _package_flag(arg.haskell_toolchain)
     ghc_args = cmd_args()
     ghc_args.add("-hide-all-packages")
-    ghc_args.add(package_flag, "base")
 
     ghc_args.add(cmd_args(arg.toolchain_libs, prepend=package_flag))
     ghc_args.add(cmd_args(packages_info.exposed_package_args))
@@ -346,7 +345,7 @@ def get_packages_info2(
     hidden_args = [l for lib in libs.traverse() for l in lib.libs]
 
     exposed_package_libs = cmd_args()
-    exposed_package_args = cmd_args([package_flag, "base"], hidden = hidden_args)
+    exposed_package_args = cmd_args()
 
     if for_deps:
         package_db_projection = "deps_package_db"

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -455,6 +455,7 @@ def _make_package(
             for module in md["module_graph"].keys()
             if not module.endswith("-boot")
         ]
+        virtual_modules = ctx.attrs.virtual_modules
 
         # XXX use a single import dir when this package db is used for resolving dependencies with ghc -M,
         #     which works around an issue with multiple import dirs resulting in GHC trying to locate interface files
@@ -469,7 +470,7 @@ def _make_package(
             "id: " + pkgname,
             "key: " + pkgname,
             "exposed: False",
-            "exposed-modules: " + ", ".join(modules),
+            "exposed-modules: " + ", ".join(modules + virtual_modules),
             "import-dirs:" + ", ".join(import_dirs),
             "depends: " + ", ".join([lib.id for lib in hlis]),
         ]


### PR DESCRIPTION
the same as Cabal virtual-modules. This is necessary to support ghc-prim compilation.

The modules listed in `virtual_modules` are added to exposed modules in package.conf without actual source codes.