### PR TITLE
Package name adjustment avoiding --.

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -818,7 +818,13 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
     indexing_tsets = {}
     sub_targets = {}
 
-    libname = repr(ctx.label.path).replace("//", "_").replace("/", "_") + "_" + ctx.label.name
+    libprefix = repr(ctx.label.path).replace("//", "_").replace("/", "_")
+
+    # avoid consecutive "--" in package name, which is not allowed by ghc-pkg.
+    if libprefix[-1] == '_':
+        libname = libprefix + ctx.label.name
+    else:
+        libname = libprefix + "_" + ctx.label.name
     pkgname = libname.replace("_", "-")
 
     md_file = target_metadata(


### PR DESCRIPTION
with --, ghc-pkg will complain. That happens if the package is located at the top-level directory in the previous name generation, so it is fixed.