### PR TITLE
Use argfile for stub dir copy if use_argfile_at_link is on

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -865,8 +865,8 @@ def compile(
     stubs_dir = ctx.actions.declare_output("stubs-" + artifact_suffix, dir=True)
 
     # collect the stubs from all modules into the stubs_dir
-    ctx.actions.run(
-        cmd_args([
+    if ctx.attrs.use_argsfile_at_link:
+        stub_copy_cmd = cmd_args([
             "bash", "-exuc",
             """\
             mkdir -p \"$0\"
@@ -874,9 +874,29 @@ def compile(
               find \"$stub\" -mindepth 1 -maxdepth 1 -exec cp -r -t \"$0\" '{}' ';'
             done
             """,
-            stubs_dir.as_output(),
-            stub_dirs
-        ]),
+        ])
+        stub_copy_cmd.add(stubs_dir.as_output())
+        stub_copy_cmd.add(at_argfile(
+            actions = ctx.actions,
+            name = "haskell_stubs_" + artifact_suffix + ".argsfile",
+            args = stub_dirs,
+            allow_args = True,
+        ))
+    else:
+        stub_copy_cmd = cmd_args([
+            "bash", "-exuc",
+            """\
+            mkdir -p \"$0\"
+            for stub; do
+              find \"$stub\" -mindepth 1 -maxdepth 1 -exec cp -r -t \"$0\" '{}' ';'
+            done
+            """,
+        ])
+        stub_copy_cmd.add(stubs_dir.as_output())
+        stub_copy_cmd.add(stub_dirs)
+
+    ctx.actions.run(
+        stub_copy_cmd,
         category = "haskell_stubs",
         identifier = artifact_suffix,
         local_only = True,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -50,7 +50,7 @@ load(
     "@prelude//linking:link_info.bzl",
     "LinkStyle",
 )
-load("@prelude//utils:argfile.bzl", "at_argfile")
+load("@prelude//utils:argfile.bzl", "argfile", "at_argfile")
 load("@prelude//:paths.bzl", "paths")
 load("@prelude//utils:graph_utils.bzl", "post_order_traversal")
 load("@prelude//utils:strings.bzl", "strip_prefix")
@@ -870,13 +870,13 @@ def compile(
             "bash", "-exuc",
             """\
             mkdir -p \"$0\"
-            for stub; do
+            cat $1 | while read stub; do
               find \"$stub\" -mindepth 1 -maxdepth 1 -exec cp -r -t \"$0\" '{}' ';'
             done
             """,
         ])
         stub_copy_cmd.add(stubs_dir.as_output())
-        stub_copy_cmd.add(at_argfile(
+        stub_copy_cmd.add(argfile(
             actions = ctx.actions,
             name = "haskell_stubs_" + artifact_suffix + ".argsfile",
             args = stub_dirs,


### PR DESCRIPTION
The arg list is too long, so it needs to be wrapped in argfile.