### PR TITLE
use -fwrite-if-simplified-core to avoid unused bytecode generation

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -686,7 +686,7 @@ def _compile_module(
     compile_cmd.add(cmd_args(library_deps, prepend = "-package"))
     compile_cmd.add(cmd_args(toolchain_deps, prepend = "-package"))
 
-    compile_cmd.add("-fbyte-code-and-object-code")
+    compile_cmd.add("-fwrite-if-simplified-core")
     if enable_th:
         compile_cmd.add("-fprefer-byte-code")
 


### PR DESCRIPTION
We can't do anything with the target's bytecode during its compilation session, so the simpler flag is sufficient.