### PR TITLE
module_prefix for adjusting interface file (hi/dyn_hi) path

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -76,6 +76,13 @@ def _use_argsfile_at_link_arg():
 """),
     }
 
+def _module_prefix_arg():
+    return {
+        "module_prefix": attrs.option(attrs.string(), default = None, doc = """
+    Module prefix if needed
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
@@ -85,4 +92,5 @@ haskell_common = struct(
     external_tools_arg = _external_tools_arg,
     srcs_envs_arg = _srcs_envs_arg,
     use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
+    module_prefix_arg = _module_prefix_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -52,6 +52,7 @@ haskell_binary = prelude_rule(
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
+        haskell_common.module_prefix_arg() |
         buck.platform_deps_arg() |
         {
             "contacts": attrs.list(attrs.string(), default = []),
@@ -173,6 +174,7 @@ haskell_library = prelude_rule(
         haskell_common.compiler_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
+        haskell_common.module_prefix_arg() |
         buck.platform_deps_arg() |
         native_common.link_whole(link_whole_type = attrs.bool(default = False)) |
         native_common.preferred_linkage(preferred_linkage_type = attrs.enum(Linkage.values())) |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -123,7 +123,7 @@ def _strip_prefix(prefix, s):
     return stripped if stripped != None else s
 
 
-def _modules_by_name(ctx: AnalysisContext, *, sources: list[Artifact], link_style: LinkStyle, enable_profiling: bool, suffix: str) -> dict[str, _Module]:
+def _modules_by_name(ctx: AnalysisContext, *, sources: list[Artifact], link_style: LinkStyle, enable_profiling: bool, suffix: str, module_prefix: str | None) -> dict[str, _Module]:
     modules = {}
 
     osuf, hisuf = output_extensions(link_style, enable_profiling)
@@ -136,7 +136,10 @@ def _modules_by_name(ctx: AnalysisContext, *, sources: list[Artifact], link_styl
             continue
 
         module_name = src_to_module_name(src.short_path) + bootsuf
-        interface_path = paths.replace_extension(src.short_path, "." + hisuf + bootsuf)
+        if module_prefix:
+            interface_path = paths.replace_extension(module_prefix.replace(".", "/") + "/" + src.short_path, "." + hisuf + bootsuf)
+        else:
+            interface_path = paths.replace_extension(src.short_path, "." + hisuf + bootsuf)
         interface = ctx.actions.declare_output("mod-" + suffix, interface_path)
         interfaces = [interface]
         object_path = paths.replace_extension(src.short_path, "." + osuf + bootsuf)
@@ -810,7 +813,7 @@ def compile(
         pkgname: str | None = None) -> CompileResultInfo:
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
 
-    modules = _modules_by_name(ctx, sources = ctx.attrs.srcs, link_style = link_style, enable_profiling = enable_profiling, suffix = artifact_suffix)
+    modules = _modules_by_name(ctx, sources = ctx.attrs.srcs, link_style = link_style, enable_profiling = enable_profiling, suffix = artifact_suffix, module_prefix = ctx.attrs.module_prefix)
 
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 


### PR DESCRIPTION
If BUCK file is located inside a package source tree, then the earlier part of module source paths are truncated, and thus the resultant pkg.conf will have wrong information. 
Though it is desirable to get correct module names, they are only correctly available as a result of parsing, i.e. needs to be implemented as dynamic values, which can complicate the situation. So for now (or forever), I assume that user can provide module prefix for that target without difficulty. Interface path is then adjusted with the prefix. 