### PR TITLE
Pass `-dynamic` flag to GHC linking binaries in shared link style

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1403,6 +1403,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
         link.add(cmd_args(hidden = linkable_artifacts))
     else:
         link.add(cmd_args(unpack_link_args(infos), prepend = "-optl"))
+        link.add("-dynamic")
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,


### PR DESCRIPTION
This ensures that we link against shared libraries of haskell packages and obviates the need to pass `-rdynamic` / `-fwhole-archive-hs-libs` on Linux and macOS, respectively.

@avdv 's commit. 