### PR TITLE
Merge experiments to mercury branch 2025-04-21

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -53,6 +53,7 @@ def _scripts_arg():
             providers = [RunInfo],
             default = "prelude//haskell/tools:ghc_wrapper",
         ),
+        "_worker": attrs.option(attrs.exec_dep(providers = [WorkerInfo]), default = None),
     }
 
 def _external_tools_arg():

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -68,6 +68,7 @@ haskell_binary = prelude_rule(
             "linker_flags": attrs.list(attrs.arg(), default = []),
             "platform": attrs.option(attrs.string(), default = None),
             "platform_linker_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg())), default = []),
+            "allow_worker": attrs.bool(default = True),
         }
     ),
 )
@@ -192,6 +193,7 @@ haskell_library = prelude_rule(
             "linker_flags": attrs.list(attrs.arg(), default = []),
             "platform": attrs.option(attrs.string(), default = None),
             "platform_linker_flags": attrs.list(attrs.tuple(attrs.regex(), attrs.list(attrs.arg())), default = []),
+            "allow_worker": attrs.bool(default = True),
         }
     ),
 )

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -407,7 +407,7 @@ def get_packages_info2(
     packagedb_args.add(package_db_tset.project_as_args("package_db"))
 
     direct_package_paths = [package_db[name].value.path for name in direct_toolchain_libs if name in package_db]
-    bin_paths = cmd_args(direct_package_paths, format="--bin-path={}/bin")
+    bin_paths = cmd_args(direct_package_paths, prepend="--bin-path", format="{}/bin")
 
     # Expose only the packages we depend on directly
     for lib in haskell_direct_deps_lib_infos:
@@ -527,7 +527,8 @@ def _common_compile_module_args(
     direct_package_paths = [package_db[name].value.path for name in direct_toolchain_libs if name in package_db]
     args_for_file.add(cmd_args(
         direct_package_paths,
-        format="--bin-path={}/bin",
+        prepend="--bin-path",
+        format="{}/bin",
     ))
 
     args_for_file.add(cmd_args(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -242,7 +242,7 @@ def target_metadata(
         sources: list[Artifact],
         suffix: str = "",
     ) -> Artifact:
-    md_file = ctx.actions.declare_output(ctx.attrs.name + suffix + ".md.json")
+    md_file = ctx.actions.declare_output(ctx.label.name + suffix + ".md.json")
     md_gen = ctx.attrs._generate_target_metadata[RunInfo]
 
     libname = repr(ctx.label.path).replace("//", "_").replace("/", "_") + "_" + ctx.label.name

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1225,7 +1225,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
 
     toolchain_libs = [dep[HaskellToolchainLibrary].name for dep in ctx.attrs.deps if HaskellToolchainLibrary in dep]
 
-    output = ctx.actions.declare_output(ctx.attrs.name)
+    output = ctx.actions.declare_output(ctx.label.name)
     link = cmd_args(haskell_toolchain.compiler)
 
     objects = {}
@@ -1434,7 +1434,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     ))
 
     if link_style == LinkStyle("shared") or link_group_info != None:
-        sos_dir = "__{}__shared_libs_symlink_tree".format(ctx.attrs.name)
+        sos_dir = "__{}__shared_libs_symlink_tree".format(ctx.label.name)
         rpath_ref = get_rpath_origin(get_cxx_toolchain_info(ctx).linker_info.type)
         rpath_ldflag = "-Wl,{}/{}".format(rpath_ref, sos_dir)
         link.add("-optl", "-Wl,-rpath", "-optl", rpath_ldflag)

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1501,6 +1501,8 @@ def _persistent_worker(ctx: AnalysisContext) -> WorkerInfo | None:
         # TODO: This is the final intended design, so we will remove this feature flag
         # from ghc-persistent-worker soon.
         cmd.add("--single")
+        if haskell_toolchain.worker_make:
+            cmd.add("--make")
         return WorkerInfo(cmd)
     else:
         return None

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -847,6 +847,7 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
     md_file = target_metadata(
         ctx,
         sources = ctx.attrs.srcs,
+        worker = _persistent_worker(ctx),
     )
     sub_targets["metadata"] = [DefaultInfo(default_output = md_file)]
 
@@ -1208,7 +1209,11 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     if enable_profiling and link_style == LinkStyle("shared"):
         link_style = LinkStyle("static")
 
-    md_file = target_metadata(ctx, sources = ctx.attrs.srcs)
+    md_file = target_metadata(
+        ctx,
+        sources = ctx.attrs.srcs,
+        worker = _persistent_worker(ctx),
+    )
 
     # Provisional hack to have a worker ID
     libname = repr(ctx.label.path).replace("//", "_").replace("/", "_") + "_" + ctx.label.name

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1491,6 +1491,11 @@ def _persistent_worker(ctx: AnalysisContext) -> WorkerInfo | None:
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
     worker = haskell_toolchain.worker
     if worker:
-        return WorkerInfo(worker)
+        cmd = cmd_args(worker)
+        # only a single worker process.
+        # TODO: This is the final intended design, so we will remove this feature flag
+        # from ghc-persistent-worker soon.
+        cmd.add("--single")
+        return WorkerInfo(cmd)
     else:
         return None

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -600,6 +600,10 @@ def _dynamic_link_shared_impl(actions, pkg_deps, lib, arg):
     link_cmd = cmd_args(link_cmd_args, hidden = link_cmd_hidden)
     link_cmd.add("-o", lib)
 
+    if arg.haskell_toolchain.use_persistent_workers:
+        link_cmd.add("--worker-target-id={}".format(arg.worker_target_id))
+        link_cmd.add("--worker-close")
+
     actions.run(
         link_cmd,
         category = "haskell_link" + arg.artifact_suffix.replace("-", "_"),
@@ -693,6 +697,7 @@ def _build_haskell_lib(
                 objects = objects,
                 toolchain_libs = toolchain_libs,
                 use_argsfile_at_link = ctx.attrs.use_argsfile_at_link,
+                worker_target_id = pkgname,
             ),
         ))
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -43,6 +43,7 @@ HaskellToolchainInfo = provider(
         "use_persistent_workers": provider_field(typing.Any, default = None),
         "use_worker": provider_field(bool, default = False),
         "worker": provider_field(typing.Any, default = None),
+        "worker_make": provider_field(bool, default = False),
         "ghc_dir": provider_field(typing.Any, default = None),
     },
 )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -41,6 +41,9 @@ HaskellToolchainInfo = provider(
         "script_template_processor": provider_field(typing.Any, default = None),
         "packages": provider_field(typing.Any, default = None),
         "use_persistent_workers": provider_field(typing.Any, default = None),
+        "use_worker": provider_field(bool, default = False),
+        "worker": provider_field(typing.Any, default = None),
+        "ghc_dir": provider_field(typing.Any, default = None),
     },
 )
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -40,6 +40,7 @@ HaskellToolchainInfo = provider(
         "cache_links": provider_field(typing.Any, default = None),
         "script_template_processor": provider_field(typing.Any, default = None),
         "packages": provider_field(typing.Any, default = None),
+        "use_persistent_workers": provider_field(typing.Any, default = None),
     },
 )
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -76,6 +76,11 @@ def main():
         default=[],
         help="Add given path to PATH.",
     )
+    parser.add_argument(
+        "--build-plan",
+        type=str,
+        help="Previously obtained build plan",
+    )
     args = parser.parse_args()
 
     result = obtain_target_metadata(args)
@@ -91,7 +96,10 @@ def json_default_handler(o):
 
 def obtain_target_metadata(args):
     paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
-    ghc_depends = run_ghc_depends(args.ghc, args.ghc_arg, args.source, paths, args.worker_target_id)
+    if args.build_plan == None:
+        ghc_depends = run_ghc_depends(args.ghc, args.ghc_arg, args.source, paths, args.worker_target_id)
+    else:
+        ghc_depends = load_toolchain_packages(args.build_plan)
     th_modules = determine_th_modules(ghc_depends)
     module_mapping = determine_module_mapping(ghc_depends, args.source_prefix)
     module_graph = determine_module_graph(ghc_depends)

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -36,6 +36,11 @@ def main():
         type=argparse.FileType("w"),
         help="Write package metadata to this file in JSON format.")
     parser.add_argument(
+        "--worker-target-id",
+        required=False,
+        type=str,
+        help="Worker id")
+    parser.add_argument(
         "--ghc",
         required=True,
         type=str,
@@ -86,7 +91,7 @@ def json_default_handler(o):
 
 def obtain_target_metadata(args):
     paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()]
-    ghc_depends = run_ghc_depends(args.ghc, args.ghc_arg, args.source, paths)
+    ghc_depends = run_ghc_depends(args.ghc, args.ghc_arg, args.source, paths, args.worker_target_id)
     th_modules = determine_th_modules(ghc_depends)
     module_mapping = determine_module_mapping(ghc_depends, args.source_prefix)
     module_graph = determine_module_graph(ghc_depends)
@@ -185,12 +190,16 @@ def determine_package_deps(ghc_depends):
     return package_deps
 
 
-def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
+def run_ghc_depends(ghc, ghc_args, sources, aux_paths, worker_target_id):
     with tempfile.TemporaryDirectory() as dname:
         json_fname = os.path.join(dname, "depends.json")
         make_fname = os.path.join(dname, "depends.make")
         haskell_sources = list(filter(is_haskell_src, sources))
-
+        haskell_boot_sources = list(filter (is_haskell_boot, sources))
+        if worker_target_id:
+            worker_args = ["--worker-target-id={}".format(worker_target_id)]
+        else:
+            worker_args = []
         args = [
             ghc, "-M", "-include-pkg-deps",
             # Note: `-outputdir '.'` removes the prefix of all targets:
@@ -198,7 +207,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths):
             "-outputdir", ".",
             "-dep-json", json_fname,
             "-dep-makefile", make_fname,
-        ] + ghc_args + haskell_sources
+        ] + worker_args + ghc_args + haskell_sources + haskell_boot_sources
 
         env = os.environ.copy()
         path = env.get("PATH", "")

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -46,6 +46,9 @@ def main():
         "--ghc", required=True, type=str, help="Path to the Haskell compiler GHC."
     )
     parser.add_argument(
+        "--ghc-dir", type=str, help="Worker option"
+    )
+    parser.add_argument(
         "--abi-out",
         required=True,
         type=Path,


### PR DESCRIPTION
- Pass a CLI option to the worker that identifies the current target
- Use `ctx.label.name` instead of `ctx.attrs.name`
- Pass `--bin-path` flag separately from the value
- New gRPC ghc-persistent-worker integration
- Use --single mode for worker
- Split metadata into haskell_buildplan and haskell_metadata for worker
- Add config option for enabling the make-mode worker