### PR TITLE
Sync 2025-06-07

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -436,12 +436,13 @@ def get_packages_info2(
 
     for lib in libs.traverse():
         packagedb_set[get_db(lib)] = None
-        hidden_args = cmd_args(hidden = [
-            lib.import_dirs.values(),
-            lib.stub_dirs,
-            lib.libs,
-        ])
-        exposed_package_args.add(hidden_args)
+        if not for_deps:
+            hidden_args = cmd_args(hidden = [
+                lib.import_dirs.values(),
+                lib.stub_dirs,
+                lib.libs,
+            ])
+            exposed_package_args.add(hidden_args)
 
     if pkg_deps:
         package_db = pkg_deps.providers[DynamicHaskellPackageDbInfo].packages

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -225,7 +225,7 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
         bp_args = cmd_args()
         bp_args.add("--ghc", arg.haskell_toolchain.compiler)
         bp_args.add("--ghc-dir", haskell_toolchain.ghc_dir)
-        add_worker_args(bp_args, arg.pkgname)
+        add_worker_args(haskell_toolchain, bp_args, arg.pkgname)
 
         build_plan = actions.declare_output(arg.pkgname + ".depends.json")
         makefile = actions.declare_output(arg.pkgname + ".depends.make")
@@ -489,11 +489,12 @@ CommonCompileModuleArgs = record(
 )
 
 def add_worker_args(
+    haskell_toolchain: HaskellToolchainInfo,
     command: cmd_args,
     pkgname: str | None,
 ) -> None:
     if pkgname != None:
-        command.add("--worker-target-id", to_hash(pkgname))
+        command.add("--worker-target-id", "singleton" if haskell_toolchain.worker_make else to_hash(pkgname))
 
 def _common_compile_module_args(
     actions: AnalysisActions,
@@ -521,7 +522,7 @@ def _common_compile_module_args(
     command.add("--ghc-dir", haskell_toolchain.ghc_dir)
 
     if allow_worker and haskell_toolchain.use_worker:
-        add_worker_args(command, pkgname)
+        add_worker_args(haskell_toolchain, command, pkgname)
 
     # Some rules pass in RTS (e.g. `+RTS ... -RTS`) options for GHC, which can't
     # be parsed when inside an argsfile.

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -261,6 +261,8 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
             category = "haskell_metadata",
             identifier = arg.suffix if arg.suffix else None,
             weight = 8,
+            # explicit turn this on for local_only actions to upload their results.
+            allow_cache_upload = True,
         )
     else:
         actions.run(
@@ -268,6 +270,8 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
             category = "haskell_metadata",
             identifier = arg.suffix if arg.suffix else None,
             weight = 8,
+            # explicit turn this on for local_only actions to upload their results.
+            allow_cache_upload = True,
         )
 
     return []

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -527,6 +527,8 @@ def _make_package(
             category = "haskell_package_" + artifact_suffix.replace("-", "_"),
             identifier = "empty" if use_empty_lib else "final",
             env = {"GHC_PACKAGE_PATH": ghc_package_path} if db_deps else {},
+            # explicit turn this on for local_only actions to upload their results.
+            allow_cache_upload = True,
         )
 
     ctx.actions.dynamic_output(


### PR DESCRIPTION
Highlights
- haskell_metadata and haskell_packages_* are now cacheable
- worker-target-id is mandatory, so make mode has that argument as well (as global target id)
- Important bug fix which hurt cross-package parallelism.
