### PR TITLE
add metadata subtargets to Haskell toolchain libraries

### DIFF
--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -177,8 +177,48 @@ def _attr_preferred_linkage(ctx: AnalysisContext) -> Linkage:
 
 # --
 
+def _toolchain_target_metadata_impl(actions, output, libname, pkg_deps, md_gen) -> list[Provider]:
+    package_db = pkg_deps.providers[DynamicHaskellPackageDbInfo].packages
+
+    md_args = cmd_args(md_gen, "--package-name", libname, "--output", output)
+    if libname in package_db:
+        pkg = package_db[libname].reduce("root")
+        md_args.add("--package-dir", pkg.db)
+
+    actions.run(
+        md_args,
+        category = "haskell_toolchain_library_metadata",
+        identifier = libname
+    )
+
+    return []
+
+_toolchain_target_metadata = dynamic_actions(
+    impl = _toolchain_target_metadata_impl,
+    attrs = {
+        "output": dynattrs.output(),
+        "libname": dynattrs.value(typing.Any),
+        "pkg_deps": dynattrs.option(dynattrs.dynamic_value()),
+        "md_gen": dynattrs.value(typing.Any),
+    },
+)
+
 def haskell_toolchain_library_impl(ctx: AnalysisContext):
-    return [DefaultInfo(), HaskellToolchainLibrary(name = ctx.attrs.name)]
+    md_file = ctx.actions.declare_output(ctx.label.name + ".md.json")
+    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
+    pkg_deps = haskell_toolchain.packages.dynamic if haskell_toolchain.packages else None
+    ctx.actions.dynamic_output_new(
+        _toolchain_target_metadata(output=md_file.as_output(),
+                                   libname=ctx.attrs.name,
+                                   pkg_deps=pkg_deps,
+                                   md_gen=ctx.attrs._generate_toolchain_lib_metadata[RunInfo],
+                                   )
+    )
+    sub_targets = { "metadata": [DefaultInfo(default_output = md_file)] }
+    return [
+        DefaultInfo(sub_targets = sub_targets),
+        HaskellToolchainLibrary(name = ctx.attrs.name)
+    ]
 
 # --
 

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -66,9 +66,15 @@ HaskellPackage = record(
 def _haskell_package_info_as_package_db(p: HaskellPackage):
     return cmd_args(p.db)
 
+def _haskell_package_set_root(children: list[HaskellPackage], p: HaskellPackage | None):
+    return p
+
 HaskellPackageDbTSet = transitive_set(
     args_projections = {
         "package_db": _haskell_package_info_as_package_db,
+    },
+    reductions = {
+        "root": _haskell_package_set_root,
     }
 )
 

--- a/haskell/tools/BUCK
+++ b/haskell/tools/BUCK
@@ -19,6 +19,12 @@ prelude.python_bootstrap_binary(
 )
 
 prelude.python_bootstrap_binary(
+    name = "generate_toolchain_lib_metadata",
+    main = "generate_toolchain_lib_metadata.py",
+    visibility = ["PUBLIC"]
+)
+
+prelude.python_bootstrap_binary(
     name = "ghc_wrapper",
     main = "ghc_wrapper.py",
     visibility = ["PUBLIC"],

--- a/haskell/tools/generate_toolchain_lib_metadata.py
+++ b/haskell/tools/generate_toolchain_lib_metadata.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+"""Helper script to generate metadata about Haskell targets provided by the Haskell toolchain.
+
+The result is a JSON object with the following fields:
+* `exposed_modules`: List of modules exposed by the package.
+"""
+
+import argparse
+import sys
+import json
+import shlex
+import subprocess
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--package-name", required=True, type=str, help="Read info about this package."
+    )
+    parser.add_argument(
+        "--package-dir",
+        required=False,
+        type=str,
+        help="Read package info from this directory.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=argparse.FileType("w"),
+        help="Write package metadata to this file in JSON format.",
+    )
+
+    args = parser.parse_args()
+    result = obtain_lib_metadata(args.package_name, args.package_dir)
+
+    json.dump(result, args.output, indent=4, default=json_default_handler)
+
+
+def json_default_handler(o):
+    if isinstance(o, set):
+        return sorted(o)
+    raise TypeError(f"Object of type {o.__class__.__name__} is not JSON serializable")
+
+
+def obtain_lib_metadata(package_name, pkgdb):
+    exposed_modules = determine_exposed_modules(package_name, pkgdb)
+    return {"exposed_modules": exposed_modules}
+
+
+def determine_exposed_modules(package_name, pkgdb):
+    package_data = run_ghc_pkg(
+        "field", pkgdb, args=[package_name, "exposed-modules", "--simple-output"]
+    )
+    return package_data.split()
+
+
+def run_ghc_pkg(cmd, pkgdb=None, args=[]):
+    outer_args = ["ghc-pkg", cmd] + args
+    if pkgdb:
+        outer_args += [f"--package-db={pkgdb}"]
+
+    res = subprocess.run(outer_args, capture_output=True)
+
+    if res.returncode != 0:
+        print(shlex.join(args), file=sys.stderr)
+
+    # Always forward stdout/stderr.
+    # Note, Buck2 swallows stdout on successful builds.
+    # Redirect to stderr to avoid this.
+    sys.stderr.buffer.write(res.stdout)
+    sys.stderr.buffer.write(res.stderr)
+
+    if res.returncode != 0:
+        # Fail if ghc-pkg failed.
+        sys.exit(res.returncode)
+
+    return res.stdout.decode("utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/haskell/tools/generate_toolchain_lib_metadata.py
+++ b/haskell/tools/generate_toolchain_lib_metadata.py
@@ -64,12 +64,6 @@ def run_ghc_pkg(cmd, pkgdb=None, args=[]):
     if res.returncode != 0:
         print(shlex.join(args), file=sys.stderr)
 
-    # Always forward stdout/stderr.
-    # Note, Buck2 swallows stdout on successful builds.
-    # Redirect to stderr to avoid this.
-    sys.stderr.buffer.write(res.stdout)
-    sys.stderr.buffer.write(res.stderr)
-
     if res.returncode != 0:
         # Fail if ghc-pkg failed.
         sys.exit(res.returncode)

--- a/rules_impl.bzl
+++ b/rules_impl.bzl
@@ -554,6 +554,13 @@ inlined_extra_attributes = {
         "_cxx_toolchain": toolchains_common.cxx(),
         "_haskell_toolchain": toolchains_common.haskell(),
     },
+    "haskell_toolchain_library": {
+        "_haskell_toolchain": toolchains_common.haskell(),
+        "_generate_toolchain_lib_metadata": attrs.dep(
+            providers = [RunInfo],
+            default = "prelude//haskell/tools:generate_toolchain_lib_metadata"
+        )
+    },
     "llvm_link_bitcode": {
         "_cxx_toolchain": toolchains_common.cxx(),
     },


### PR DESCRIPTION
- Adds a subtarget named `metadata` to Haskell toolchain library targets.
  - The subtarget generates a JSON file containing an object with exactly one field, named `"exposed_modules"`, which contains a list of the names of modules exposed by the package.
- Also adds `"exposed_modules"` to the `metadata` subtargets of `haskell_library` targets.
  - This is redundant with information already present in the `"module_graph"` field, but having this field will simplify the implementation of `module_target_map:best_effort` in mwb (and also simplify TargetCalc a bit).