### PR TITLE
Sync 2025-07-28

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -84,6 +84,13 @@ def _module_prefix_arg():
 """),
     }
 
+def _strip_prefix_arg():
+    return {
+        "strip_prefix": attrs.list(attrs.string(), default = [], doc = """
+    Strip prefix such as src, lib, app or test
+"""),
+    }
+
 def _extra_libraries_arg():
     return {
         "extra_libraries": attrs.list(attrs.dep(), default = [], doc = """
@@ -108,6 +115,7 @@ haskell_common = struct(
     srcs_envs_arg = _srcs_envs_arg,
     use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
     module_prefix_arg = _module_prefix_arg,
+    strip_prefix_arg = _strip_prefix_arg,
     extra_libraries_arg = _extra_libraries_arg,
     incremental_arg = _incremental_arg,
 )

--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -91,6 +91,13 @@ def _extra_libraries_arg():
 """),
     }
 
+def _incremental_arg():
+    return {
+        "incremental": attrs.bool(default = True, doc = """
+    Use module-level incremental build
+"""),
+    }
+
 haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
@@ -102,4 +109,5 @@ haskell_common = struct(
     use_argsfile_at_link_arg = _use_argsfile_at_link_arg,
     module_prefix_arg = _module_prefix_arg,
     extra_libraries_arg = _extra_libraries_arg,
+    incremental_arg = _incremental_arg,
 )

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -54,6 +54,7 @@ haskell_binary = prelude_rule(
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |
+        haskell_common.strip_prefix_arg() |
         haskell_common.incremental_arg() |
         buck.platform_deps_arg() |
         {
@@ -179,6 +180,7 @@ haskell_library = prelude_rule(
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |
+        haskell_common.strip_prefix_arg() |
         haskell_common.incremental_arg() |
         buck.platform_deps_arg() |
         native_common.link_whole(link_whole_type = attrs.bool(default = False)) |

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -54,6 +54,7 @@ haskell_binary = prelude_rule(
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |
+        haskell_common.incremental_arg() |
         buck.platform_deps_arg() |
         {
             "contacts": attrs.list(attrs.string(), default = []),
@@ -178,6 +179,7 @@ haskell_library = prelude_rule(
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |
+        haskell_common.incremental_arg() |
         buck.platform_deps_arg() |
         native_common.link_whole(link_whole_type = attrs.bool(default = False)) |
         native_common.preferred_linkage(preferred_linkage_type = attrs.enum(Linkage.values())) |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -927,6 +927,7 @@ def compile_args(
         main,
         deps,
         sources,
+        external_tool_paths,
         link_style: LinkStyle,
         enable_profiling: bool,
         package_env_args: cmd_args,
@@ -997,6 +998,12 @@ def compile_args(
     pre_args = pre.set.project_as_args("args")
     compile_args.add(cmd_args(pre_args, format = "-optP={}"))
 
+    compile_args.add(cmd_args(
+        external_tool_paths,
+        format="--bin-exe={}",
+    ))
+
+
     if pkgname:
         compile_args.add(["-this-unit-id", pkgname])
 
@@ -1055,7 +1062,8 @@ def _compile_non_incr(
     link_style = arg.link_style
     enable_profiling = arg.enable_profiling
 
-    compile_cmd = cmd_args(haskell_toolchain.compiler, hidden = outputs.values())
+    compile_cmd = cmd_args(arg.ghc_wrapper, hidden = outputs.values())
+    compile_cmd.add("--ghc", haskell_toolchain.compiler)
 
     args = compile_args(
         actions,
@@ -1065,6 +1073,7 @@ def _compile_non_incr(
         main = arg.main,
         deps = arg.deps,
         sources = arg.sources,
+        external_tool_paths = arg.external_tool_paths,
         link_style = link_style,
         enable_profiling = enable_profiling,
         package_env_args = common_args.package_env_args,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -897,6 +897,7 @@ def compile_args(
         sources,
         link_style: LinkStyle,
         enable_profiling: bool,
+        package_env_args: cmd_args,
         pkgname = None,
         suffix: str = "") -> CompileArgsInfo:
 
@@ -913,7 +914,8 @@ def compile_args(
 
     compile_args = cmd_args()
     compile_args.add("-no-link", "-i")
-    compile_args.add("-package-env=-")
+
+    compile_args.add(package_env_args)
 
     if enable_profiling:
         compile_args.add("-prof")
@@ -1006,6 +1008,7 @@ def _compile_non_incr(
 
     compile_cmd = cmd_args(haskell_toolchain.compiler, hidden = outputs.values())
 
+
     args = compile_args(
         actions,
         haskell_toolchain = haskell_toolchain,
@@ -1016,6 +1019,7 @@ def _compile_non_incr(
         sources = arg.sources,
         link_style = link_style,
         enable_profiling = enable_profiling,
+        package_env_args = common_args.package_env_args,
         pkgname = arg.pkgname,
     )
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -955,6 +955,10 @@ def compile_args(
     if enable_profiling:
         compile_args.add("-prof")
 
+    compile_args.add("-fbyte-code-and-object-code")
+    compile_args.add("-fprefer-byte-code")
+    compile_args.add("-j")
+
     if link_style == LinkStyle("shared"):
         compile_args.add("-dynamic", "-fPIC")
     elif link_style == LinkStyle("static_pic"):

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -178,7 +178,7 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
 
-    packages_info = get_packages_info2(
+    packages_info = get_packages_info(
         actions,
         arg.deps,
         arg.direct_deps_link_info,
@@ -370,33 +370,6 @@ def _package_flag(toolchain: HaskellToolchainInfo) -> str:
         return "-package"
 
 def get_packages_info(
-        ctx: AnalysisContext,
-        link_style: LinkStyle,
-        specify_pkg_version: bool,
-        enable_profiling: bool,
-        use_empty_lib: bool) -> PackagesInfo:
-    haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
-
-    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
-        ctx,
-        link_style,
-        enable_profiling,
-    )
-
-    return get_packages_info2(
-        actions = ctx.actions,
-        deps = [],
-        direct_deps_link_info = attr_deps_haskell_link_infos(ctx),
-        haskell_toolchain = haskell_toolchain,
-        haskell_direct_deps_lib_infos = haskell_direct_deps_lib_infos,
-        link_style = link_style,
-        specify_pkg_version = specify_pkg_version,
-        enable_profiling = enable_profiling,
-        use_empty_lib = use_empty_lib,
-        pkg_deps = None,
-    )
-
-def get_packages_info2(
     actions: AnalysisActions,
     deps: list[Dependency],
     direct_deps_link_info: list[HaskellLinkInfo],

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -55,7 +55,7 @@ load(
     "@prelude//haskell:compile.bzl",
     "CompileResultInfo",
     "compile",
-    "get_packages_info2",
+    "get_packages_info",
     "target_metadata",
 )
 load(
@@ -1210,7 +1210,7 @@ def _dynamic_link_binary_impl(actions, pkg_deps, output, arg):
 
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
-    packages_info = get_packages_info2(
+    packages_info = get_packages_info(
         actions,
         deps = arg.deps,
         direct_deps_link_info = arg.direct_deps_link_info,

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -662,6 +662,7 @@ def _build_haskell_lib(
         md_file = md_file,
         pkgname = pkgname,
         worker = worker,
+        incremental = ctx.attrs.incremental,
     )
     solibs = {}
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
@@ -1289,6 +1290,7 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
     compiled = compile(
         ctx,
         link_style,
+        incremental = ctx.attrs.incremental,
         enable_profiling = enable_profiling,
         enable_haddock = False,
         md_file = md_file,

--- a/haskell/haskell_ghci.bzl
+++ b/haskell/haskell_ghci.bzl
@@ -30,7 +30,13 @@ load(
     "@prelude//haskell:toolchain.bzl",
     "HaskellToolchainInfo",
 )
-load("@prelude//haskell:util.bzl", "attr_deps", "get_artifact_suffix")
+load(
+    "@prelude//haskell:util.bzl",
+    "attr_deps",
+    "attr_deps_haskell_lib_infos",
+    "attr_deps_haskell_link_infos",
+    "get_artifact_suffix",
+)
 load("@prelude//linking:execution_preference.bzl", "LinkExecutionPreference")
 load(
     "@prelude//linking:link_info.bzl",
@@ -638,12 +644,23 @@ def haskell_ghci_impl(ctx: AnalysisContext) -> list[Provider]:
     link_style = LinkStyle("shared")
     #link_style = LinkStyle("static_pic")
 
-    packages_info = get_packages_info(
+    haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,
         link_style,
+        enable_profiling,
+    )
+
+    packages_info = get_packages_info(
+        actions = ctx.actions,
+        deps = [],
+        direct_deps_link_info = attr_deps_haskell_link_infos(ctx),
+        haskell_toolchain = haskell_toolchain,
+        haskell_direct_deps_lib_infos = haskell_direct_deps_lib_infos,
+        link_style = link_style,
         specify_pkg_version = True,
         enable_profiling = enable_profiling,
         use_empty_lib = False,
+        pkg_deps = None,
     )
 
     # Create package db symlinks


### PR DESCRIPTION
This is a big update for the hybrid build.

- Added incremental = True/False option for Haskell rules. no impl yet.
- Factor out _compile_incr for module_tsets fill-in part
- Rename: get_packages_info2 -> get_packages_info.
- Non-incremental package build: compile
- Factor out make_package_env
- Use package env file for non-incr build
- Provide package dep parameters for non-incr build
- CompiledModuleTSet for non-incremental build
- Use full package db for for non-incr build.
- Canonicalize interface/object file location
- Use ghc_wrapper.py and pass --bin-exe for non-incr builds
- prefer-byte-code, byte-code-and-object-code and -j for non-incr build
