### PR TITLE
Sync 2025-08-05

### DIFF
--- a/artifacts.bzl
+++ b/artifacts.bzl
@@ -57,7 +57,7 @@ DefaultOutputExt = provider(
 )
 
 def single_artifact(dep: Artifact | Dependency) -> ArtifactOutputs:
-    if type(dep) == "artifact":
+    if isinstance(dep, Artifact):
         return ArtifactOutputs(
             default_output = dep,
             nondebug_runtime_files = [],
@@ -94,7 +94,7 @@ def unpack_artifacts(artifacts: list[Artifact | Dependency]) -> list[ArtifactOut
     out = []
 
     for artifact in artifacts:
-        if type(artifact) == "artifact":
+        if isinstance(artifact, Artifact):
             out.append(ArtifactOutputs(
                 default_output = artifact,
                 nondebug_runtime_files = [],
@@ -124,7 +124,7 @@ def unpack_artifact_map(artifacts: dict[str, Artifact | Dependency]) -> dict[str
     out = {}
 
     for name, artifact in artifacts.items():
-        if type(artifact) == "artifact":
+        if isinstance(artifact, Artifact):
             out[name] = ArtifactOutputs(
                 default_output = artifact,
                 nondebug_runtime_files = [],

--- a/erlang/erlang_application.bzl
+++ b/erlang/erlang_application.bzl
@@ -214,7 +214,8 @@ def _generate_priv_dir(
         for file in resource[DefaultInfo].default_outputs:
             priv_symlinks[file.short_path] = file
         for file in resource[DefaultInfo].other_outputs:
-            priv_symlinks[file.short_path] = file
+            if isinstance(file, Artifact):
+                priv_symlinks[file.short_path] = file
 
     build_environment.priv_dirs[name] = ctx.actions.symlinked_dir(
         paths.join(

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -299,15 +299,13 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
         )
         md_args.add("--build-plan", build_plan)
 
-    md_args_output = actions.declare_output("dynamic_target_metadata_args")
-    actions.write(
-        md_args_output.as_output(),
-        md_args,
-        allow_args = True,
-    )
-
     md_args_outer = cmd_args(arg.md_gen)
-    md_args_outer.add(cmd_args(md_args_output, format = "@{}", hidden = md_args))
+    md_args_outer.add(at_argfile(
+        actions = actions,
+        name = "dynamic_target_metadata_args",
+        args = md_args,
+        allow_args = True,
+    ))
 
     actions.run(
         md_args_outer,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -214,13 +214,6 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
 
-    if arg.incremental:
-        use_empty_lib = True
-        for_deps = True
-    else:
-        use_empty_lib = False
-        for_deps = False
-
     packages_info = get_packages_info(
         actions,
         arg.deps,
@@ -230,8 +223,8 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
         LinkStyle("shared"),
         specify_pkg_version = False,
         enable_profiling = False,
-        use_empty_lib = use_empty_lib,
-        for_deps = for_deps,
+        use_empty_lib = True,
+        for_deps = False,
         pkg_deps = pkg_deps,
     )
     package_flag = _package_flag(arg.haskell_toolchain)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -676,10 +676,10 @@ def _common_compile_module_args(
     # target-level dependencies. needed for non-incremental build.
     target_deps_args = cmd_args()
 
-    for pkg in toolchain_deps_by_name.keys():
+    for pkg in toolchain_deps_by_name:
         target_deps_args.add(cmd_args(pkg, prepend = "-package"))
 
-    for pkg in direct_deps_by_name.keys():
+    for pkg in direct_deps_by_name:
         target_deps_args.add(cmd_args(pkg, prepend = "-package"))
 
     return CommonCompileModuleArgs(
@@ -1046,7 +1046,7 @@ def compile_args(
         args_for_file = compile_args,
     )
 
-def _make_module_tset_non_incr(
+def _make_module_tsets_non_incr(
         actions: AnalysisActions,
         module: _Module,
         package_deps: dict[str, list[str]],
@@ -1147,7 +1147,7 @@ def _compile_non_incr(
 
     for module_name in post_order_traversal(graph):
         module = mapped_modules[module_name]
-        module_tsets[module_name] = _make_module_tset_non_incr(
+        module_tsets[module_name] = _make_module_tsets_non_incr(
             actions,
             module = module,
             package_deps = package_deps.get(module_name, {}),

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -939,6 +939,7 @@ def compile_args(
         enable_profiling: bool,
         direct_deps_link_info,
         haskell_direct_deps_lib_infos,
+        extra_libraries,
         package_env_args: cmd_args,
         target_deps_args: cmd_args,
         pkgname = None,
@@ -950,6 +951,22 @@ def compile_args(
     # be parsed when inside an argsfile.
     compile_cmd.add(compiler_flags)
 
+    # extra-libraries
+    extra_libs = [
+        lib[NativeToolchainLibrary]
+        for lib in extra_libraries
+        if NativeToolchainLibrary in lib
+    ]
+    for l in extra_libs:
+        compile_cmd.add(l.lib_path)
+        compile_cmd.add("-l{}".format(l.name))
+
+    compile_cmd.add("-fbyte-code-and-object-code")
+    compile_cmd.add("-fprefer-byte-code")
+    compile_cmd.add("-j")
+
+    ####
+
     compile_args = cmd_args()
     compile_args.add("-no-link", "-i")
 
@@ -958,10 +975,6 @@ def compile_args(
 
     if enable_profiling:
         compile_args.add("-prof")
-
-    compile_args.add("-fbyte-code-and-object-code")
-    compile_args.add("-fprefer-byte-code")
-    compile_args.add("-j")
 
     if link_style == LinkStyle("shared"):
         compile_args.add("-dynamic", "-fPIC")
@@ -1111,6 +1124,7 @@ def _compile_non_incr(
         link_style = link_style,
         direct_deps_link_info = arg.direct_deps_link_info,
         haskell_direct_deps_lib_infos = arg.haskell_direct_deps_lib_infos,
+        extra_libraries = arg.extra_libraries,
         enable_profiling = enable_profiling,
         package_env_args = common_args.package_env_args,
         target_deps_args = common_args.target_deps_args,

--- a/js/js_library.bzl
+++ b/js/js_library.bzl
@@ -24,7 +24,7 @@ def _get_grouped_srcs(ctx: AnalysisContext) -> list[GroupedSource]:
     for src in ctx.attrs.srcs:
         # TODO(ianc) also support sources with an "inner path".
         expect(
-            type(src) == "artifact",
+            isinstance(src, Artifact),
             "src {} is not an artifact, its type is: {}".format(src, type(src)),
         )
         canonical_src_name = get_canonical_src_name(src.short_path)

--- a/python/python_library.bzl
+++ b/python/python_library.bzl
@@ -224,7 +224,6 @@ def py_attr_resources(ctx: AnalysisContext) -> dict[str, ArtifactOutputs]:
     Return the resources provided by this rule, as a map of resource name to
     a tuple of the resource artifact and any "other" outputs exposed by it.
     """
-
     return unpack_artifact_map(_attr_resources(ctx))
 
 def py_resources(
@@ -237,7 +236,7 @@ def py_resources(
     hidden = []
     for name, resource in resources.items():
         for o in resource.nondebug_runtime_files:
-            if type(o) == "artifact" and o.basename == shared_libs_symlink_tree_name(resource.default_output):
+            if isinstance(o, Artifact) and o.basename == shared_libs_symlink_tree_name(resource.default_output):
                 # Package the binary's shared libs next to the binary
                 # (the path is stored in RPATH relative to the binary).
                 d[paths.join(paths.dirname(name), o.basename)] = o

--- a/sh_test.bzl
+++ b/sh_test.bzl
@@ -18,7 +18,7 @@ def sh_test_impl(ctx: AnalysisContext) -> list[Provider]:
     args_hidden = []
 
     if ctx.attrs.test != None:
-        if type(ctx.attrs.test) == "artifact":
+        if isinstance(ctx.attrs.test, Artifact):
             args_args.append(ctx.attrs.test)
         elif isinstance(ctx.attrs.test, Dependency):
             run_info = ctx.attrs.test.get(RunInfo)

--- a/utils/utils.bzl
+++ b/utils/utils.bzl
@@ -36,7 +36,7 @@ def from_named_set(srcs: [dict[str, Artifact | Dependency], list[Artifact | Depe
     if type(srcs) == type([]):
         srcs_dict = {}
         for src in srcs:
-            if type(src) == "artifact":
+            if isinstance(src, Artifact):
                 name = src.short_path
             else:
                 # If the src is a `dependency`, use the short path of the


### PR DESCRIPTION
Important cherry-pick from buck2-prelude upstream: type(x) == "artifact"
response file for build plan step
Numerous bug fixes for hybrid build

- Changing type(x) ==(!=) "y" -> (not) isinstance(x, Y) for Artifact in fbcode bzl with `type(x) == "artifact"`
- Reformat with buildifier
- haskell_metadata: Use `at_argfile` helper
- Use response file for build plan args
- Interfaces are added to module_tsets for non-incremental build
- Use toolchain_deps_by_name and direct_deps_by_name correctly.
- No need to use full package conf for metadata in non-incr mode.
- Provide dep library info correctly in non-incr build
- Add missing extra_libraries support to non-incr build
