### PR TITLE
Sync 2025-08-12

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -373,7 +373,7 @@ def target_metadata(
             direct_deps_link_info = attr_deps_haskell_link_infos(ctx),
             haskell_direct_deps_lib_infos = haskell_direct_deps_lib_infos,
             haskell_toolchain = haskell_toolchain,
-            lib_package_name_and_prefix = _attr_deps_haskell_lib_package_name_and_prefix(ctx),
+            lib_package_name_and_prefix = _attr_deps_haskell_lib_package_name_and_prefix(ctx, link_style),
             md_gen = md_gen,
             sources = sources,
             external_tool_paths = [tool[RunInfo] for tool in ctx.attrs.external_tools],
@@ -390,7 +390,7 @@ def target_metadata(
 
     return md_file
 
-def _attr_deps_haskell_lib_package_name_and_prefix(ctx: AnalysisContext) -> cmd_args:
+def _attr_deps_haskell_lib_package_name_and_prefix(ctx: AnalysisContext, link_style: LinkStyle) -> cmd_args:
     args = cmd_args(prepend = "--package")
 
     for dep in attr_deps(ctx) + ctx.attrs.template_deps:
@@ -398,7 +398,7 @@ def _attr_deps_haskell_lib_package_name_and_prefix(ctx: AnalysisContext) -> cmd_
         if lib == None:
             continue
 
-        lib_info = lib.lib.values()[0]
+        lib_info = lib.lib[link_style]
         args.add(cmd_args(
             lib_info.name,
             cmd_args(lib_info.db, parent = 1),

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -840,6 +840,7 @@ def _compile_module(
 
     if enable_th:
         compile_cmd.add("-fprefer-byte-code")
+        compile_cmd.add("-fpackage-db-byte-code")
 
     compile_cmd.add(cmd_args(dependency_modules.reduce("packagedb_deps").keys(), prepend = "--buck2-package-db"))
 
@@ -962,6 +963,7 @@ def compile_args(
 
     compile_cmd.add("-fbyte-code-and-object-code")
     compile_cmd.add("-fprefer-byte-code")
+    compile_cmd.add("-fpackage-db-byte-code")
     compile_cmd.add("-j")
 
     ####

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -507,9 +507,8 @@ CommonCompileModuleArgs = record(
 def add_worker_args(
         haskell_toolchain: HaskellToolchainInfo,
         command: cmd_args,
-        pkgname: str | None) -> None:
-    if pkgname != None:
-        command.add("--worker-target-id", "singleton" if haskell_toolchain.worker_make else to_hash(pkgname))
+        pkgname: str) -> None:
+    command.add("--worker-target-id", "singleton" if haskell_toolchain.worker_make else to_hash(pkgname))
 
 def make_package_env(
         actions,
@@ -562,7 +561,7 @@ def _common_compile_module_args(
         allow_worker: bool,
         toolchain_deps_by_name,
         direct_deps_by_name,
-        pkgname: str | None = None) -> CommonCompileModuleArgs:
+        pkgname: str) -> CommonCompileModuleArgs:
     command = cmd_args(ghc_wrapper)
     command.add("--ghc", haskell_toolchain.compiler)
     command.add("--ghc-dir", haskell_toolchain.ghc_dir)
@@ -614,9 +613,7 @@ def _common_compile_module_args(
     pre = cxx_merge_cpreprocessors_actions(actions, [], inherited_pre)
     pre_args = pre.set.project_as_args("args")
     args_for_file.add(cmd_args(pre_args, format = "-optP={}"))
-
-    if pkgname:
-        args_for_file.add(["-this-unit-id", pkgname])
+    args_for_file.add(["-this-unit-id", pkgname])
 
     # Add -package-db and -package/-expose-package flags for each Haskell
     # library dependency.
@@ -1258,10 +1255,10 @@ def compile(
         enable_profiling: bool,
         enable_haddock: bool,
         md_file: Artifact,
+        pkgname: str,
         worker: WorkerInfo | None = None,
         incremental: bool = False,
-        is_haskell_binary: bool = False,
-        pkgname: str | None = None) -> CompileResultInfo:
+        is_haskell_binary: bool = False) -> CompileResultInfo:
     artifact_suffix = get_artifact_suffix(link_style, enable_profiling)
 
     modules = _modules_by_name(ctx, sources = ctx.attrs.srcs, link_style = link_style, enable_profiling = enable_profiling, suffix = artifact_suffix, module_prefix = ctx.attrs.module_prefix, is_haskell_binary = is_haskell_binary)

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -330,6 +330,8 @@ _dynamic_target_metadata = dynamic_actions(
 def target_metadata(
         ctx: AnalysisContext,
         *,
+        link_style: LinkStyle,
+        enable_profiling: bool,
         sources: list[Artifact],
         suffix: str = "",
         worker: WorkerInfo | None) -> Artifact:
@@ -350,8 +352,8 @@ def target_metadata(
 
     haskell_direct_deps_lib_infos = attr_deps_haskell_lib_infos(
         ctx,
-        LinkStyle("shared"),
-        enable_profiling = False,
+        link_style,
+        enable_profiling,
     )
 
     # The object and interface file paths are depending on the real module name

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -696,7 +696,6 @@ def _build_haskell_lib(
         enable_profiling: bool,
         enable_haddock: bool,
         md_file: Artifact,
-        package_env_file: Artifact | None,
         # The non-profiling artifacts are also needed to build the package for
         # profiling, so it should be passed when `enable_profiling` is True.
         non_profiling_hlib: [HaskellLibBuildOutput, None] = None) -> HaskellLibBuildOutput:
@@ -969,18 +968,6 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
 
     haskell_toolchain = ctx.attrs._haskell_toolchain[HaskellToolchainInfo]
 
-    # TODO(wavewave): Create package_env_file in compile.
-    packagedb_args = []
-    package_env_file = make_package_env(
-        ctx.actions,
-        haskell_toolchain,
-        ctx.label,
-        LinkStyle("shared"),
-        False,
-        False,
-        packagedb_args,
-    )
-
     # The non-profiling library is also needed to build the package with
     # profiling enabled, so we need to keep track of it for each link style.
     non_profiling_hlib = {}
@@ -1004,7 +991,6 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
                 # enable haddock only for the first non-profiling hlib
                 enable_haddock = not enable_profiling and not non_profiling_hlib,
                 md_file = md_file,
-                package_env_file = package_env_file,
                 non_profiling_hlib = non_profiling_hlib.get(link_style),
             )
             if not enable_profiling:

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -943,7 +943,7 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
     sub_targets = {}
     extra = {}
 
-    if(ctx.attrs.use_same_package_name):
+    if ctx.attrs.use_same_package_name:
         libname = ctx.label.name
         pkgname = libname
     else:

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -959,6 +959,8 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
 
     md_file = target_metadata(
         ctx,
+        link_style = LinkStyle("shared"),
+        enable_profiling = False,
         sources = ctx.attrs.srcs,
         worker = worker,
     )
@@ -1356,6 +1358,8 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
 
     md_file = target_metadata(
         ctx,
+        link_style = LinkStyle("shared"),
+        enable_profiling = False,
         sources = ctx.attrs.srcs,
         worker = worker,
     )


### PR DESCRIPTION
- `pkgname` is never None
- Use HaskellLibraryInfo according to link_style and profiling
- Use library dependencies according to link_style and profiling mode
- Remove unneeded package env file
- Add missing -fpackage-db-byte-code