### PR TITLE
Sync 2025-08-21

### DIFF
--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -51,6 +51,13 @@ HaskellToolchainInfo = provider(
 HaskellToolchainLibrary = provider(
     fields = {
         "name": provider_field(str),
+        "dynamic": DynamicValue,
+    },
+)
+
+DynamicHaskellToolchainLibraryInfo = provider(
+    fields = {
+        "id": provider_field(str),
     },
 )
 

--- a/haskell/tools/generate_toolchain_lib_metadata.py
+++ b/haskell/tools/generate_toolchain_lib_metadata.py
@@ -55,8 +55,16 @@ def obtain_lib_metadata(ghc_pkg, package_name, pkgdb):
     package_id = determine_id(ghc_pkg, package_name, pkgdb)
     exposed_modules = determine_exposed_modules(ghc_pkg, package_name, pkgdb)
     return {
+        "id": package_id,
         "exposed_modules": exposed_modules,
     }
+
+
+def determine_id(ghc_pkg, package_name, pkgdb):
+    package_id = run_ghc_pkg(
+        ghc_pkg, "field", pkgdb, args=[package_name, "id", "--simple-output"]
+    )
+    return package_id.strip()
 
 
 def determine_exposed_modules(ghc_pkg, package_name, pkgdb):


### PR DESCRIPTION
Toolchain Haskell libraries are correctly listed in package.conf depends!
- No implicit closure passing to write_package_conf
- Move _write_package_conf out
- No direct use of ctx in _write_package_conf.
- Convert _write_package_conf to dynamic_actions
- Pass ghc-pkg as an arg to generate_toolchain_lib_metadata.py
- package.conf depends field now has toolchain libraries.
