### PR TITLE
Handle ghc-pkg syntax for re-exported modules

### DIFF
--- a/haskell/tools/generate_toolchain_lib_metadata.py
+++ b/haskell/tools/generate_toolchain_lib_metadata.py
@@ -71,7 +71,18 @@ def determine_exposed_modules(ghc_pkg, package_name, pkgdb):
     package_data = run_ghc_pkg(
         ghc_pkg, "field", pkgdb, args=[package_name, "exposed-modules", "--simple-output"]
     )
-    return package_data.split()
+    if ',' in package_data:
+        # See https://gitlab.haskell.org/ghc/ghc/-/issues/26351
+        # If commas are present then the package probably uses module
+        # re-exports, which causes ghc-pkg to use a more complex syntax, which
+        # looks like eg
+        #
+        #   Foo.Bar, Foo.Baz, Foo.Quux from foo-quux-1.0.0-pkgid:Foo.Quux"
+        #
+        # We only care about the module names here.
+        return [m.split(' ')[0] for m in package_data.split(', ')]
+    else:
+        return package_data.split()
 
 
 def run_ghc_pkg(ghc_pkg, cmd, pkgdb=None, args=[]):

--- a/haskell/tools/generate_toolchain_lib_metadata.py
+++ b/haskell/tools/generate_toolchain_lib_metadata.py
@@ -70,7 +70,7 @@ def determine_id(ghc_pkg, package_name, pkgdb):
 def determine_exposed_modules(ghc_pkg, package_name, pkgdb):
     package_data = run_ghc_pkg(
         ghc_pkg, "field", pkgdb, args=[package_name, "exposed-modules", "--simple-output"]
-    )
+    ).strip()
     if ',' in package_data:
         # See https://gitlab.haskell.org/ghc/ghc/-/issues/26351
         # If commas are present then the package probably uses module


### PR DESCRIPTION
The metadata subtarget for Haskell packages which use module re-exports produces incorrect JSON at the moment in the case of packages which use module re-exports. This is because of a quirk in the output format of `ghc-pkg field $pkg exposed-modules --simple-output` (see https://gitlab.haskell.org/ghc/ghc/-/issues/26351), which produces a different format that this script does not handle in the case of re-exports.

For example, `//haskell:dependent-sum[metadata]` looks like this:

```
{
    "id": "dependent-sum-0.7.2.0-2ho0wpxA4qLGoWGxYelNH5",
    "exposed_modules": [
        "Data.Dependent.Sum,",
        "Data.GADT.Compare",
        "from",
        "some-1.0.6-1TvmiuXyz9Z2Z1G2j0OiNc:Data.GADT.Compare,",
        "Data.GADT.Show",
        "from",
        "some-1.0.6-1TvmiuXyz9Z2Z1G2j0OiNc:Data.GADT.Show,",
        "Data.Some",
        "from",
        "some-1.0.6-1TvmiuXyz9Z2Z1G2j0OiNc:Data.Some"
    ]
}
```

(The `base` package also has this issue but exposes many more modules, so I've opted to use `dependent-sum` to illustrate.)

This PR adds a separate branch in the script so that both syntaxes are handled. ~~I don't know how to test this in situ but I have verified that this code does what I expect it to in the Python repl.~~

I've now tested this in the context of the mwb repo by:

- Manually inspecting the output of `buck build '//haskell:base[metadata]'` and `buck build '//haskell:dependent-sum[metadata]'`
- Successfully using the `add_missing_deps` script to add a missing `base` dep on a target