### PR TITLE
haskell: display non-haskell srcs being warned about

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -591,7 +591,7 @@ def _common_compile_module_args(
     ]
 
     if non_haskell_sources:
-        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(label))
+        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead: {}".format(label, non_haskell_sources))
 
     args_for_file = cmd_args(hidden = non_haskell_sources)
 


### PR DESCRIPTION
This makes it a lot clearer what the warning is in reference to.

Before:

```
root//:foo (prelude//platforms:default#200212f73efcd57d) specifies non-haskell file in `srcs`, consider using `srcs_deps` instead
```

After:

```
root//:foo (prelude//platforms:default#200212f73efcd57d) specifies non-haskell file in `srcs`, consider using `srcs_deps` instead: [<build artifact lib-shared/libroot_src_foo.dylib bound to root//src:foo (prelude//platforms:default#200212f73efcd57d)>]
```