### PR TITLE
Sync 2025-08-27

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -591,7 +591,7 @@ def _common_compile_module_args(
     ]
 
     if non_haskell_sources:
-        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead".format(label))
+        warning("{} specifies non-haskell file in `srcs`, consider using `srcs_deps` instead: {}".format(label, non_haskell_sources))
 
     args_for_file = cmd_args(hidden = non_haskell_sources)
 


### PR DESCRIPTION
- haskell: list non-haskell `srcs` in warning
- Handle ghc-pkg module syntax for re-exported modules