### PR TITLE
Sync 2025-09-08

### DIFF
--- a/decls/haskell_common.bzl
+++ b/decls/haskell_common.bzl
@@ -36,6 +36,14 @@ def _compiler_flags_arg():
 """),
     }
 
+def _ghc_rts_flags_arg():
+    return {
+        "ghc_rts_flags": attrs.list(attrs.string(), default = [], doc = """
+    RTS options passed to GHC, changing the behavior of the compiler process, not the resulting binaries like
+    `-with-rtsopts` would.
+"""),
+    }
+
 def _exported_linker_flags_arg():
     return {
         "exported_linker_flags": attrs.list(attrs.string(), default = [], doc = """
@@ -109,6 +117,7 @@ haskell_common = struct(
     srcs_arg = _srcs_arg,
     deps_arg = _deps_arg,
     compiler_flags_arg = _compiler_flags_arg,
+    ghc_rts_flags_arg = _ghc_rts_flags_arg,
     exported_linker_flags_arg = _exported_linker_flags_arg,
     scripts_arg = _scripts_arg,
     external_tools_arg = _external_tools_arg,

--- a/decls/haskell_rules.bzl
+++ b/decls/haskell_rules.bzl
@@ -51,6 +51,7 @@ haskell_binary = prelude_rule(
         haskell_common.use_argsfile_at_link_arg () |
         haskell_common.extra_libraries_arg () |
         haskell_common.compiler_flags_arg() |
+        haskell_common.ghc_rts_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |
@@ -177,6 +178,7 @@ haskell_library = prelude_rule(
         haskell_common.use_argsfile_at_link_arg() |
         haskell_common.extra_libraries_arg() |
         haskell_common.compiler_flags_arg() |
+        haskell_common.ghc_rts_flags_arg() |
         haskell_common.deps_arg() |
         haskell_common.scripts_arg() |
         haskell_common.module_prefix_arg() |

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -333,11 +333,10 @@ def target_metadata(
         link_style: LinkStyle,
         enable_profiling: bool,
         sources: list[Artifact],
-        suffix: str = "",
         worker: WorkerInfo | None) -> Artifact:
     prof_suffix = "-prof" if enable_profiling else ""
     link_suffix = "-" + link_style.value
-    md_file = ctx.actions.declare_output(ctx.label.name + suffix + link_suffix + prof_suffix + ".md.json")
+    md_file = ctx.actions.declare_output(ctx.label.name + link_suffix + prof_suffix + ".md.json")
     md_gen = ctx.attrs._generate_target_metadata[RunInfo]
 
     libprefix = repr(ctx.label.path).replace("//", "_").replace("/", "_")
@@ -380,7 +379,7 @@ def target_metadata(
             sources = sources,
             external_tool_paths = [tool[RunInfo] for tool in ctx.attrs.external_tools],
             strip_prefix = _strip_prefix(str(ctx.label.cell_root), str(ctx.label.path)),
-            suffix = suffix,
+            suffix = link_style.value + ("+prof" if enable_profiling else ""),
             toolchain_libs = toolchain_libs,
             worker = worker,
             allow_worker = ctx.attrs.allow_worker,

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -244,7 +244,7 @@ UnitParams = record(
     external_tool_paths = field(list[RunInfo]),
     artifact_suffix = field(str),
     haskell_toolchain = field(HaskellToolchainInfo),
-    compiler_flags = field(list[str]),
+    compiler_flags = field(list[str | ResolvedStringWithMacros]),
 )
 
 # Assemble GHC arguments that are specific to a given unit, but not to a module.

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -220,9 +220,9 @@ def _dynamic_target_metadata_impl(actions, output, arg, pkg_deps) -> list[Provid
         arg.direct_deps_link_info,
         arg.haskell_toolchain,
         arg.haskell_direct_deps_lib_infos,
-        LinkStyle("shared"),
+        arg.link_style,
         specify_pkg_version = False,
-        enable_profiling = False,
+        enable_profiling = arg.enable_profiling,
         use_empty_lib = True,
         for_deps = True,
         pkg_deps = pkg_deps,
@@ -335,7 +335,9 @@ def target_metadata(
         sources: list[Artifact],
         suffix: str = "",
         worker: WorkerInfo | None) -> Artifact:
-    md_file = ctx.actions.declare_output(ctx.label.name + suffix + ".md.json")
+    prof_suffix = "-prof" if enable_profiling else ""
+    link_suffix = "-" + link_style.value
+    md_file = ctx.actions.declare_output(ctx.label.name + suffix + link_suffix + prof_suffix + ".md.json")
     md_gen = ctx.attrs._generate_target_metadata[RunInfo]
 
     libprefix = repr(ctx.label.path).replace("//", "_").replace("/", "_")
@@ -385,6 +387,8 @@ def target_metadata(
             pkgname = pkgname,
             label = ctx.label,
             incremental = ctx.attrs.incremental,
+            link_style = link_style,
+            enable_profiling = enable_profiling,
         ),
     ))
 

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -430,7 +430,7 @@ def _dynamic_target_metadata_impl(
         md_args.add("--unit-args", ghc_args_file)
 
     # pass the cell root directory as the working directory for ghc
-    md_args_outer = cmd_args(arg.md_gen, "--cwd", arg.cell_root, md_args)
+    md_args_outer = cmd_args(arg.md_gen, "--cwd", arg.cell_root)
     md_args_outer.add(at_argfile(
         actions = actions,
         name = "dynamic_target_metadata_args",

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -1111,6 +1111,7 @@ def _compile_module(
             "abi": abi_tag,
         }
     else:
+        compile_args_for_file.add(common_args.oneshot_args_for_file)
         compile_args_for_file.add(_compile_oneshot_args(
             actions,
             common_args = common_args,
@@ -1138,7 +1139,6 @@ def _compile_module(
             packagedb_tag = packagedb_tag,
         ))
 
-        compile_args_for_file.add(common_args.oneshot_args_for_file)
         compile_cmd_args.append(common_args.oneshot_wrapper_args)
 
         dep_files = {

--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -397,6 +397,7 @@ def _dynamic_target_metadata_impl(
             actions = actions,
             name = "haskell_metadata_ghc_{}.args".format(unit.name),
             args = ghc_args,
+            allow_args = True,
         )
 
         bp_args = cmd_args()

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -1065,6 +1065,8 @@ def haskell_library_impl(ctx: AnalysisContext) -> list[Provider]:
                 ctx,
                 link_style = link_style,
                 enable_profiling = enable_profiling,
+                enable_haddock = not enable_profiling and not non_profiling_hlib,
+                main = None,
                 sources = ctx.attrs.srcs,
                 worker = worker,
             )
@@ -1437,6 +1439,8 @@ def haskell_binary_impl(ctx: AnalysisContext) -> list[Provider]:
         ctx,
         link_style = link_style,
         enable_profiling = enable_profiling,
+        enable_haddock = False,
+        main = getattr(ctx.attrs, "main", None),
         sources = ctx.attrs.srcs,
         worker = worker,
     )

--- a/haskell/haskell.bzl
+++ b/haskell/haskell.bzl
@@ -331,6 +331,7 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
             version = ctx.attrs.version,
             is_prebuilt = True,
             profiling_enabled = False,
+            md_file = None,
         )
         prof_hlibinfo = HaskellLibraryInfo(
             name = ctx.attrs.name,
@@ -348,6 +349,7 @@ def haskell_prebuilt_library_impl(ctx: AnalysisContext) -> list[Provider]:
             version = ctx.attrs.version,
             is_prebuilt = True,
             profiling_enabled = True,
+            md_file = None,
         )
 
         def archive_linkable(lib):
@@ -995,6 +997,7 @@ def _build_haskell_lib(
         is_prebuilt = False,
         profiling_enabled = enable_profiling,
         dependencies = toolchain_libs,
+        md_file = md_file,
     )
 
     return HaskellLibBuildOutput(

--- a/haskell/persistent_worker.bzl
+++ b/haskell/persistent_worker.bzl
@@ -8,8 +8,10 @@ def _persistent_worker_impl(ctx: AnalysisContext) -> list[Provider]:
     worker_proxy = ctx.attrs.worker_proxy[RunInfo] # haskell_toolchain.worker_proxy
 
     cmd = cmd_args(worker_proxy, "--exe", worker)
+    cmd.add(ctx.attrs.proxy_args, "--")
     if ctx.attrs.make:
         cmd.add("--make")
+    cmd.add(ctx.attrs.worker_args)
     return [DefaultInfo(), WorkerInfo(cmd)]
 
 persistent_worker = rule(
@@ -18,5 +20,7 @@ persistent_worker = rule(
         "worker": attrs.dep(providers = [RunInfo]),
         "worker_proxy": attrs.dep(providers = [RunInfo]),
         "make": attrs.bool(default = False),
+        "proxy_args": attrs.list(attrs.arg(), default = []),
+        "worker_args": attrs.list(attrs.arg(), default = []),
     },
 )

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -45,6 +45,9 @@ HaskellToolchainInfo = provider(
         "worker_single": provider_field(typing.Any, default = False),
         "worker_make": provider_field(bool, default = False),
         "ghc_dir": provider_field(typing.Any, default = None),
+        # RTS options passed to GHC, changing the behavior of the compiler process, not the resulting binaries like
+        # `-with-rtsopts` would.
+        "ghc_rts_flags": provider_field(typing.Any, default = None),
     },
 )
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -89,6 +89,11 @@ def main():
         type=str,
         help="Previously obtained build plan",
     )
+    parser.add_argument(
+        "--unit-args",
+        type=str,
+        help="Args used to reconstruct the persistent worker's unit state when recompiling",
+    )
     args = parser.parse_args()
 
     result = obtain_target_metadata(args)
@@ -119,6 +124,10 @@ def obtain_target_metadata(args):
         "module_mapping": module_mapping,
         "module_graph": module_graph,
         "package_deps": package_deps,
+        # The original build plan output and the GHC options used to initialize the home unit env are required by the
+        # persistent worker in order to restore the state from cache.
+        "build_plan": ghc_depends,
+        "unit_args": args.unit_args,
     }
 
 

--- a/haskell/tools/generate_target_metadata.py
+++ b/haskell/tools/generate_target_metadata.py
@@ -258,7 +258,7 @@ def run_ghc_depends(ghc, ghc_args, sources, aux_paths, worker_target_id):
         res = subprocess.run(args_outer, env=env, capture_output=True)
         if res.returncode != 0:
             # Write the GHC command on failure.
-            print(shlex.join(args_outer), file=sys.stderr)
+            print(ghc, shlex.join(args), file=sys.stderr)
 
         # Always forward stdout/stderr.
         # Note, Buck2 swallows stdout on successful builds.

--- a/haskell/tools/ghc_wrapper.py
+++ b/haskell/tools/ghc_wrapper.py
@@ -49,6 +49,11 @@ def main():
         "--ghc-dir", type=str, help="Worker option"
     )
     parser.add_argument(
+        "--ghc-argsfile",
+        required=False,
+        type=str,
+        help="File path containing arguments for GHC.")
+    parser.add_argument(
         "--abi-out",
         required=False, # True,
         type=Path,
@@ -116,7 +121,8 @@ def main():
     else:
         worker_args = []
         use_persistent_workers = False
-    cmd = [args.ghc] + worker_args + ghc_args
+
+    cmd = [args.ghc] + worker_args + ghc_args + (["@" + args.ghc_argsfile] if args.ghc_argsfile else [])
 
     aux_paths = [str(binpath) for binpath in args.bin_path if binpath.is_dir()] + [str(os.path.dirname(binexepath)) for binexepath in args.bin_exe]
     env = os.environ.copy()


### PR DESCRIPTION
This sync has a big change for resumable make-mode persistent worker!
and linking now treats Haskell packages as Haskell packages, not C/C++-like general libraries, by having correct transitive information for Haskell packages.