### PR TITLE
Sync 2025-09-09

### DIFF
--- a/haskell/compile.bzl
+++ b/haskell/compile.bzl
@@ -907,7 +907,7 @@ def _compile_oneshot_args(
         if NativeToolchainLibrary in lib
     ]
     for l in extra_libs:
-        args.add(l.lib_path)
+        args.add(cmd_args(l.lib_root, l.rel_path_to_root, delimiter = "/", absolute_prefix = "-L"))
         args.add("-l{}".format(l.name))
 
     args.add(
@@ -1280,7 +1280,7 @@ def compile_args(
         if NativeToolchainLibrary in lib
     ]
     for l in extra_libs:
-        compile_cmd.add(l.lib_path)
+        compile_cmd.add(cmd_args(l.lib_root, l.rel_path_to_root, delimiter = "/", absolute_prefix = "-L"))
         compile_cmd.add("-l{}".format(l.name))
 
     compile_cmd.add("-fbyte-code-and-object-code")

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -42,7 +42,6 @@ HaskellToolchainInfo = provider(
         "packages": provider_field(typing.Any, default = None),
         "use_persistent_workers": provider_field(typing.Any, default = None),
         "use_worker": provider_field(bool, default = False),
-        "worker_single": provider_field(typing.Any, default = False),
         "worker_make": provider_field(bool, default = False),
         "ghc_dir": provider_field(typing.Any, default = None),
         # RTS options passed to GHC, changing the behavior of the compiler process, not the resulting binaries like

--- a/haskell/toolchain.bzl
+++ b/haskell/toolchain.bzl
@@ -94,6 +94,7 @@ DynamicHaskellPackageDbInfo = provider(fields = {
 NativeToolchainLibrary = provider(
     fields = {
         "name": provider_field(str),
-        "lib_path": provider_field(typing.Any, default = None),
+        "lib_root": provider_field(Artifact),
+        "rel_path_to_root": provider_field(str),
     },
 )


### PR DESCRIPTION
- Remove obsolete field `HaskellToolchainInfo.worker_single`
- Added non-Haskell toolchain extra-libraries to package.conf